### PR TITLE
feat(common): create scheme for database and api calls

### DIFF
--- a/Documentation/build_documentation.md
+++ b/Documentation/build_documentation.md
@@ -148,6 +148,25 @@ cargo test -p security-module
 
 ## Running Locally
 
+### 0. Start *a* database
+
+The api server requires a database, which by default is expected as a Postgres instance running on `localhost:5432`. A local container instance can be managed like this:
+
+```bash
+cd .devcontainer/
+
+# start the container
+podman-compose up -d postgres
+
+# stop the container
+podman-compose down postgres
+
+# optional: to delete the data (volume)
+podman volume rm devcontainer_postgres_data
+```
+
+**Alternatively for local development** an sqlite database can be used. For that, just define a sqlite connection string via the config or an environment variable when running the server, e.g.: `APP_DATABASE_URL="sqlite://db.sqlite?mode=rwc" cargo run ..."`
+
 ### 1. Start the API mock server
 
 The mock server simulates the Cloud API on `localhost:80`:

--- a/api-mock-server/src/config.rs
+++ b/api-mock-server/src/config.rs
@@ -38,7 +38,7 @@ pub fn get_config(config_path: Option<PathBuf>) -> Result<Settings, config::Conf
 
 pub fn validate_config(config: &Settings) -> Result<(), String> {
     if !config.database_url.starts_with("postgres://")
-        && !config.database_url.starts_with("sqlite::memory:")
+        && !config.database_url.starts_with("sqlite:")
     {
         return Err("Database connection url must begin with `postgres://`".into());
     }

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -5,7 +5,9 @@ use sea_orm_migration::MigratorTrait;
 use tokio::sync::RwLock;
 
 use crate::db_migration::Migrator;
-use amos_common::entities::{Application, ApplicationAssignment, ApplicationConfig, Device, Group, Tenant};
+use amos_common::entities::{
+    Application, ApplicationAssignment, ApplicationConfig, Device, Group, Tenant,
+};
 
 static DB: RwLock<Option<DatabaseConnection>> = RwLock::const_new(None);
 

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -105,10 +105,7 @@ pub async fn add_application_config(
     let db = db!();
 
     let new_app_config = app_config.insert(&db).await?;
-    debug!(
-        "Inserted new application config: {:?}",
-        new_app_config
-    );
+    debug!("Inserted new application config: {:?}", new_app_config);
 
     Ok(new_app_config)
 }
@@ -129,7 +126,10 @@ async fn add_application_assignment(
     let db = db!();
 
     let new_app_assignment = app_assignment.insert(&db).await?;
-    debug!("Inserted new application config assignment: {:?}", new_app_assignment);
+    debug!(
+        "Inserted new application config assignment: {:?}",
+        new_app_assignment
+    );
 
     Ok(new_app_assignment)
 }

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -5,7 +5,7 @@ use sea_orm_migration::MigratorTrait;
 use tokio::sync::RwLock;
 
 use crate::db_migration::Migrator;
-use amos_common::entities::{Device, Group};
+use amos_common::entities::{Application, ApplicationAssignment, ApplicationConfig, Device, Group};
 
 static DB: RwLock<Option<DatabaseConnection>> = RwLock::const_new(None);
 
@@ -32,7 +32,7 @@ pub async fn initialialize_db(database_url: String) -> Result<(), DbErr> {
 }
 
 #[allow(dead_code)]
-pub async fn add_group(name: String) -> Result<i32, DbErr> {
+pub async fn add_group(name: String) -> Result<Group::Model, DbErr> {
     let group = Group::ActiveModel {
         id: NotSet,
         name: Set(name.to_owned()),
@@ -44,7 +44,7 @@ pub async fn add_group(name: String) -> Result<i32, DbErr> {
     let new_group = group.insert(&db).await?;
     debug!("Inserted group: {:?}", new_group);
 
-    Ok(new_group.id)
+    Ok(new_group)
 }
 
 #[allow(dead_code)]
@@ -52,7 +52,7 @@ pub async fn add_device(
     uuid: String,
     hostname: String,
     group_id: Option<i32>,
-) -> Result<i32, DbErr> {
+) -> Result<Device::Model, DbErr> {
     let device = Device::ActiveModel {
         id: NotSet,
         uuid: Set(uuid),
@@ -65,7 +65,86 @@ pub async fn add_device(
     let new_device = device.insert(&db).await?;
     debug!("Inserted device: {:?}", new_device);
 
-    Ok(new_device.id)
+    Ok(new_device)
+}
+
+#[allow(dead_code)]
+pub async fn add_application(
+    name: String,
+    description: String,
+) -> Result<Application::Model, DbErr> {
+    let app = Application::ActiveModel {
+        id: NotSet,
+        name: Set(name),
+        description: Set(description),
+    };
+
+    let db = db!();
+
+    let new_app = app.insert(&db).await?;
+    debug!("Inserted new application: {:?}", new_app);
+
+    Ok(new_app)
+}
+
+#[allow(dead_code)]
+pub async fn add_application_config(
+    app_id: i32,
+    image: String,
+    config: Option<String>,
+    comment: Option<String>,
+) -> Result<ApplicationConfig::Model, DbErr> {
+    let app_config = ApplicationConfig::ActiveModel {
+        id: NotSet,
+        application_id: Set(app_id),
+        image: Set(image),
+        config: Set(config),
+        comment: Set(comment),
+    };
+
+    let db = db!();
+
+    let new_app_config = app_config.insert(&db).await?;
+    debug!("Inserted new application config: {:?}", new_app_config);
+
+    Ok(new_app_config)
+}
+
+#[allow(dead_code)]
+async fn add_application_assignment(
+    app_config_id: i32,
+    device_id: Option<i32>,
+    group_id: Option<i32>,
+) -> Result<ApplicationAssignment::Model, DbErr> {
+    let app_assignment = ApplicationAssignment::ActiveModel {
+        id: NotSet,
+        application_config_id: Set(app_config_id),
+        device_id: Set(device_id),
+        group_id: Set(group_id),
+    };
+
+    let db = db!();
+
+    let new_app_assignment = app_assignment.insert(&db).await?;
+    debug!("Inserted new application config assignment: {:?}", new_app_assignment);
+
+    Ok(new_app_assignment)
+}
+
+#[allow(dead_code)]
+pub async fn add_application_assignment_to_device(
+    app_config_id: i32,
+    device_id: i32,
+) -> Result<ApplicationAssignment::Model, DbErr> {
+    add_application_assignment(app_config_id, Some(device_id), None).await
+}
+
+#[allow(dead_code)]
+pub async fn add_application_assignment_to_group(
+    app_config_id: i32,
+    group_id: i32,
+) -> Result<ApplicationAssignment::Model, DbErr> {
+    add_application_assignment(app_config_id, Some(group_id), None).await
 }
 
 #[cfg(test)]
@@ -90,13 +169,13 @@ mod tests {
     async fn test_insert_device_with_existing_group() {
         test_initialize_empty_inmem_db().await;
 
-        let gid = super::add_group("Wurschtwerk Erlangen #5".into())
+        let group = super::add_group("Wurschtwerk Erlangen #5".into())
             .await
             .unwrap();
         super::add_device(
             "c0ffee-xdxdxd-129874".to_owned(),
             "host-01.er5.weber.group".to_owned(),
-            Some(gid),
+            Some(group.id),
         )
         .await
         .unwrap();
@@ -113,6 +192,43 @@ mod tests {
             Some(0),
         )
         .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_insert_app_assignement_for_device_works() {
+        test_initialize_empty_inmem_db().await;
+
+        let device = super::add_device("".to_owned(), "".to_owned(), None).await.unwrap();
+        println!("Created device: {:?}", device);
+
+        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned()).await.unwrap();
+        println!("Created app: {:?}", app);
+
+        let app_config = super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None).await.unwrap();
+        println!("Created app config: {:?}", app_config);
+
+        let result = super::add_application_assignment_to_device(app_config.id, device.id).await;
+        println!("Created application assignment: {:?}", result);
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_insert_app_assignement_without_group_or_device_fails() {
+        test_initialize_empty_inmem_db().await;
+
+        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned()).await.unwrap();
+        println!("Created app: {:?}", app);
+
+        let app_config = super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None).await.unwrap();
+        println!("Created app config: {:?}", app_config);
+
+        let result = super::add_application_assignment(app_config.id, None, None).await;
+        println!("Created application assignment: {:?}", result);
 
         assert!(result.is_err());
     }

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -32,10 +32,7 @@ pub async fn initialialize_db(database_url: String) -> Result<(), DbErr> {
 }
 
 #[allow(dead_code)]
-pub async fn add_tenant(
-    name: String,
-    description: Option<String>,
-) -> Result<Tenant::Model, DbErr> {
+pub async fn add_tenant(name: String, description: Option<String>) -> Result<Tenant::Model, DbErr> {
     let tenant = Tenant::ActiveModel {
         id: NotSet,
         name: Set(name),
@@ -194,13 +191,14 @@ mod tests {
     async fn test_insert_device_with_existing_group_and_tenant_works() {
         test_initialize_empty_inmem_db().await;
 
-        let tenant =
-            super::add_tenant("Kathis Käjsewelt".to_owned(), Some("Sitz: Nürnberg".to_owned()))
-                .await
-                .unwrap();
-        let group = super::add_group("Werk Erlangen #5".into())
-            .await
-            .unwrap();
+        let tenant = super::add_tenant(
+            "Kathis Käjsewelt".to_owned(),
+            Some("Sitz: Nürnberg".to_owned()),
+        )
+        .await
+        .unwrap();
+        let group = super::add_group("Werk Erlangen #5".into()).await.unwrap();
+
         super::add_device(
             "c0ffee-xdxdxd-129874".to_owned(),
             "host-01.er5.weber.group".to_owned(),

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -105,7 +105,10 @@ pub async fn add_application_config(
     let db = db!();
 
     let new_app_config = app_config.insert(&db).await?;
-    debug!("Inserted new application config: {:?}", new_app_config);
+    debug!(
+        "Inserted new application config: {:?}",
+        new_app_config
+    );
 
     Ok(new_app_config)
 }
@@ -202,13 +205,20 @@ mod tests {
     async fn test_insert_app_assignement_for_device_works() {
         test_initialize_empty_inmem_db().await;
 
-        let device = super::add_device("".to_owned(), "".to_owned(), None).await.unwrap();
+        let device = super::add_device("".to_owned(), "".to_owned(), None)
+            .await
+            .unwrap();
         println!("Created device: {:?}", device);
 
-        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned()).await.unwrap();
+        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned())
+            .await
+            .unwrap();
         println!("Created app: {:?}", app);
 
-        let app_config = super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None).await.unwrap();
+        let app_config =
+            super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None)
+                .await
+                .unwrap();
         println!("Created app config: {:?}", app_config);
 
         let result = super::add_application_assignment_to_device(app_config.id, device.id).await;
@@ -222,10 +232,15 @@ mod tests {
     async fn test_insert_app_assignement_without_group_or_device_fails() {
         test_initialize_empty_inmem_db().await;
 
-        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned()).await.unwrap();
+        let app = super::add_application("App 1".to_owned(), "Sample app".to_owned())
+            .await
+            .unwrap();
         println!("Created app: {:?}", app);
 
-        let app_config = super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None).await.unwrap();
+        let app_config =
+            super::add_application_config(app.id, "quay.io/bla".to_owned(), None, None)
+                .await
+                .unwrap();
         println!("Created app config: {:?}", app_config);
 
         let result = super::add_application_assignment(app_config.id, None, None).await;
@@ -239,7 +254,9 @@ mod tests {
     async fn generated_application_model_json_matches_expected() {
         test_initialize_empty_inmem_db().await;
 
-        let app = super::add_application("app-a".to_owned(), "cool app".to_owned()).await.unwrap();
+        let app = super::add_application("app-a".to_owned(), "cool app".to_owned())
+            .await
+            .unwrap();
         let app_json = serde_json::to_string(&app).unwrap();
 
         let expected = r#"{"id":1,"name":"app-a","description":"cool app"}"#;

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -149,6 +149,7 @@ pub async fn add_application_assignment_to_group(
 
 #[cfg(test)]
 mod tests {
+    use sea_orm::sea_query::prelude::serde_json;
     use serial_test::serial;
 
     #[cfg(test)]
@@ -231,5 +232,28 @@ mod tests {
         println!("Created application assignment: {:?}", result);
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn generated_application_model_json_matches_expected() {
+        test_initialize_empty_inmem_db().await;
+
+        let app = super::add_application("app-a".to_owned(), "cool app".to_owned()).await.unwrap();
+        let app_json = serde_json::to_string(&app).unwrap();
+
+        let expected = r#"{"id":1,"name":"app-a","description":"cool app"}"#;
+        assert_eq!(app_json, expected);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn given_application_model_json_unmarshalls() {
+        test_initialize_empty_inmem_db().await;
+
+        let app_json = r#"{"id":5,"name":"app-b","description":"mediocre app"}"#;
+        let app: Result<super::Application::Model, _> = serde_json::from_str(app_json);
+
+        assert!(app.is_ok());
     }
 }

--- a/api-mock-server/src/db.rs
+++ b/api-mock-server/src/db.rs
@@ -5,7 +5,7 @@ use sea_orm_migration::MigratorTrait;
 use tokio::sync::RwLock;
 
 use crate::db_migration::Migrator;
-use amos_common::entities::{Application, ApplicationAssignment, ApplicationConfig, Device, Group};
+use amos_common::entities::{Application, ApplicationAssignment, ApplicationConfig, Device, Group, Tenant};
 
 static DB: RwLock<Option<DatabaseConnection>> = RwLock::const_new(None);
 
@@ -32,6 +32,25 @@ pub async fn initialialize_db(database_url: String) -> Result<(), DbErr> {
 }
 
 #[allow(dead_code)]
+pub async fn add_tenant(
+    name: String,
+    description: Option<String>,
+) -> Result<Tenant::Model, DbErr> {
+    let tenant = Tenant::ActiveModel {
+        id: NotSet,
+        name: Set(name),
+        description: Set(description),
+    };
+
+    let db = db!();
+
+    let new_tenant = tenant.insert(&db).await?;
+    debug!("Inserted new tenant: {:?}", new_tenant);
+
+    Ok(new_tenant)
+}
+
+#[allow(dead_code)]
 pub async fn add_group(name: String) -> Result<Group::Model, DbErr> {
     let group = Group::ActiveModel {
         id: NotSet,
@@ -51,12 +70,14 @@ pub async fn add_group(name: String) -> Result<Group::Model, DbErr> {
 pub async fn add_device(
     uuid: String,
     hostname: String,
+    tenant_id: i32,
     group_id: Option<i32>,
 ) -> Result<Device::Model, DbErr> {
     let device = Device::ActiveModel {
         id: NotSet,
         uuid: Set(uuid),
         hostname: Set(hostname),
+        tenant_id: Set(tenant_id),
         group_id: Set(group_id),
     };
 
@@ -170,15 +191,20 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_insert_device_with_existing_group() {
+    async fn test_insert_device_with_existing_group_and_tenant_works() {
         test_initialize_empty_inmem_db().await;
 
-        let group = super::add_group("Wurschtwerk Erlangen #5".into())
+        let tenant =
+            super::add_tenant("Kathis Käjsewelt".to_owned(), Some("Sitz: Nürnberg".to_owned()))
+                .await
+                .unwrap();
+        let group = super::add_group("Werk Erlangen #5".into())
             .await
             .unwrap();
         super::add_device(
             "c0ffee-xdxdxd-129874".to_owned(),
             "host-01.er5.weber.group".to_owned(),
+            tenant.id,
             Some(group.id),
         )
         .await
@@ -190,9 +216,12 @@ mod tests {
     async fn test_insert_device_with_not_existing_group_fails() {
         test_initialize_empty_inmem_db().await;
 
+        let tenant = super::add_tenant("X".to_owned(), None).await.unwrap();
+
         let result = super::add_device(
             "c0ffee-xdxdxd-129874".to_owned(),
             "host-01.er5.weber.group".to_owned(),
+            tenant.id,
             Some(0),
         )
         .await;
@@ -205,7 +234,9 @@ mod tests {
     async fn test_insert_app_assignement_for_device_works() {
         test_initialize_empty_inmem_db().await;
 
-        let device = super::add_device("".to_owned(), "".to_owned(), None)
+        let tenant = super::add_tenant("X".to_owned(), None).await.unwrap();
+
+        let device = super::add_device("".to_owned(), "".to_owned(), tenant.id, None)
             .await
             .unwrap();
         println!("Created device: {:?}", device);

--- a/api-mock-server/src/db_migration/m20220101_000001_create_table.rs
+++ b/api-mock-server/src/db_migration/m20220101_000001_create_table.rs
@@ -14,8 +14,14 @@ impl MigrationTrait for Migration {
         let schema = Schema::new(manager.get_database_backend());
 
         // Don't switch table creation order randomly, it depends on foreign key presence
+        // EDIT: ...in Postgres at least, it seems
         create_table(manager, &schema, entities::Group::Entity).await?;
         create_table(manager, &schema, entities::Device::Entity).await?;
+        create_table(manager, &schema, entities::Application::Entity).await?;
+        create_table(manager, &schema, entities::ApplicationConfig::Entity).await?;
+        create_table(manager, &schema, entities::ApplicationAssignment::Entity).await?;
+        create_table(manager, &schema, entities::OsVersion::Entity).await?;
+        create_table(manager, &schema, entities::OsAssignment::Entity).await?;
 
         Ok(())
     }

--- a/api-mock-server/src/db_migration/m20220101_000001_create_table.rs
+++ b/api-mock-server/src/db_migration/m20220101_000001_create_table.rs
@@ -15,6 +15,7 @@ impl MigrationTrait for Migration {
 
         // Don't switch table creation order randomly, it depends on foreign key presence
         // EDIT: ...in Postgres at least, it seems
+        create_table(manager, &schema, entities::Tenant::Entity).await?;
         create_table(manager, &schema, entities::Group::Entity).await?;
         create_table(manager, &schema, entities::Device::Entity).await?;
         create_table(manager, &schema, entities::Application::Entity).await?;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,9 +9,6 @@ anyhow = "1.0.102"
 futures-util = "0.3.32"
 reqwest = { version = "0.13.3", features = ["json", "stream"] }
 sea-orm = { workspace = true }
-serde_json.workspace = true
+serde_json = { workspace = true }
 tokio = { version = "1.52.2", features = ["full"] }
 base64 = "0.22"
-
-[dev-dependencies]
-serde_json = "1"

--- a/common/src/entities.rs
+++ b/common/src/entities.rs
@@ -1,5 +1,20 @@
+pub mod application;
+pub use crate::entities::application as Application;
+
+pub mod application_assignment;
+pub use crate::entities::application_assignment as ApplicationAssignment;
+
+pub mod application_config;
+pub use crate::entities::application_config as ApplicationConfig;
+
 pub mod device;
 pub use crate::entities::device as Device;
 
 pub mod group;
 pub use crate::entities::group as Group;
+
+pub mod os_assignment;
+pub use crate::entities::os_assignment as OsAssignment;
+
+pub mod os_version;
+pub use crate::entities::os_version as OsVersion;

--- a/common/src/entities.rs
+++ b/common/src/entities.rs
@@ -18,3 +18,6 @@ pub use crate::entities::os_assignment as OsAssignment;
 
 pub mod os_version;
 pub use crate::entities::os_version as OsVersion;
+
+pub mod tenant;
+pub use crate::entities::tenant as Tenant;

--- a/common/src/entities/application.rs
+++ b/common/src/entities/application.rs
@@ -15,7 +15,6 @@ pub struct Model {
     pub description: String,
 
     #[sea_orm(has_many)]
-    #[serde(skip)]
     pub applications: HasMany<ApplicationConfig::Entity>,
 }
 

--- a/common/src/entities/application.rs
+++ b/common/src/entities/application.rs
@@ -1,21 +1,20 @@
 use sea_orm::entity::prelude::*;
 
-use super::Group;
+use super::ApplicationConfig;
 
 #[sea_orm::model]
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
-#[sea_orm(table_name = "devices")]
+#[sea_orm(table_name = "applications")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]
     pub id: i32,
 
-    pub uuid: String,
+    pub name: String,
 
-    pub hostname: String,
+    pub description: String,
 
-    pub group_id: Option<i32>,
-    #[sea_orm(belongs_to, from = "group_id", to = "id")]
-    pub group: HasOne<Group::Entity>,
+    #[sea_orm(has_many)]
+    pub applications: HasMany<ApplicationConfig::Entity>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/common/src/entities/application.rs
+++ b/common/src/entities/application.rs
@@ -1,9 +1,10 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::ApplicationConfig;
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "applications")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]
@@ -14,6 +15,7 @@ pub struct Model {
     pub description: String,
 
     #[sea_orm(has_many)]
+    #[serde(skip)]
     pub applications: HasMany<ApplicationConfig::Entity>,
 }
 

--- a/common/src/entities/application_assignment.rs
+++ b/common/src/entities/application_assignment.rs
@@ -26,19 +26,17 @@ pub struct Model {
 
 #[async_trait::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    async fn before_save<C>(
-        self,
-        _db: &C,
-        _insert: bool,
-    ) -> Result<Self, DbErr>
+    async fn before_save<C>(self, _db: &C, _insert: bool) -> Result<Self, DbErr>
     where
         C: ConnectionTrait,
     {
         let has_device = matches!(self.device_id.clone(), ActiveValue::Set(Some(_)));
-        let has_group  = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
+        let has_group = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
 
         if !has_device && !has_group {
-            return Err(DbErr::Custom("Either device_id or group_id must be set".into()));
+            return Err(DbErr::Custom(
+                "Either device_id or group_id must be set".into()
+            ));
         }
 
         Ok(self)

--- a/common/src/entities/application_assignment.rs
+++ b/common/src/entities/application_assignment.rs
@@ -35,7 +35,7 @@ impl ActiveModelBehavior for ActiveModel {
 
         if !has_device && !has_group {
             return Err(DbErr::Custom(
-                "Either device_id or group_id must be set".into()
+                "Either device_id or group_id must be set".into(),
             ));
         }
 

--- a/common/src/entities/application_assignment.rs
+++ b/common/src/entities/application_assignment.rs
@@ -1,0 +1,44 @@
+use sea_orm::entity::prelude::*;
+
+use super::{ApplicationConfig, Device, Group};
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "application_assignments")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+
+    pub application_id: i32,
+    #[sea_orm(belongs_to, from = "application_id", to = "id")]
+    pub application: HasOne<ApplicationConfig::Entity>,
+
+    pub device_id: Option<i32>,
+    #[sea_orm(belongs_to, from = "device_id", to = "id")]
+    pub device: HasOne<Device::Entity>,
+
+    pub group_id: Option<i32>,
+    #[sea_orm(belongs_to, from = "group_id", to = "id")]
+    pub group: HasOne<Group::Entity>,
+}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(
+        self,
+        _db: &C,
+        _insert: bool,
+    ) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let has_device = self.device_id.clone().into_value().is_some();
+        let has_group = self.group_id.clone().into_value().is_some();
+
+        if !has_device && !has_group {
+            return Err(DbErr::Custom("Either device_id or group_id must be set".into()));
+        }
+
+        Ok(self)
+    }
+}

--- a/common/src/entities/application_assignment.rs
+++ b/common/src/entities/application_assignment.rs
@@ -1,10 +1,11 @@
 use sea_orm::ActiveValue;
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::{ApplicationConfig, Device, Group};
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "application_assignments")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/application_assignment.rs
+++ b/common/src/entities/application_assignment.rs
@@ -1,3 +1,4 @@
+use sea_orm::ActiveValue;
 use sea_orm::entity::prelude::*;
 
 use super::{ApplicationConfig, Device, Group};
@@ -9,9 +10,9 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]
     pub id: i32,
 
-    pub application_id: i32,
-    #[sea_orm(belongs_to, from = "application_id", to = "id")]
-    pub application: HasOne<ApplicationConfig::Entity>,
+    pub application_config_id: i32,
+    #[sea_orm(belongs_to, from = "application_config_id", to = "id")]
+    pub application_config: HasOne<ApplicationConfig::Entity>,
 
     pub device_id: Option<i32>,
     #[sea_orm(belongs_to, from = "device_id", to = "id")]
@@ -32,8 +33,8 @@ impl ActiveModelBehavior for ActiveModel {
     where
         C: ConnectionTrait,
     {
-        let has_device = self.device_id.clone().into_value().is_some();
-        let has_group = self.group_id.clone().into_value().is_some();
+        let has_device = matches!(self.device_id.clone(), ActiveValue::Set(Some(_)));
+        let has_group  = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
 
         if !has_device && !has_group {
             return Err(DbErr::Custom("Either device_id or group_id must be set".into()));

--- a/common/src/entities/application_config.rs
+++ b/common/src/entities/application_config.rs
@@ -9,7 +9,7 @@ use super::Application;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]
     pub id: i32,
-    
+
     pub application_id: i32,
     #[sea_orm(belongs_to, from = "application_id", to = "id")]
     pub application: HasOne<Application::Entity>,

--- a/common/src/entities/application_config.rs
+++ b/common/src/entities/application_config.rs
@@ -1,0 +1,23 @@
+use sea_orm::entity::prelude::*;
+
+use super::Application;
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "application_configs")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+    
+    pub application_id: i32,
+    #[sea_orm(belongs_to, from = "application_id", to = "id")]
+    pub application: HasOne<Application::Entity>,
+
+    pub image: String,
+
+    pub config: Option<String>,
+
+    pub comment: Option<String>,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/common/src/entities/application_config.rs
+++ b/common/src/entities/application_config.rs
@@ -1,9 +1,10 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::Application;
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "application_configs")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/device.rs
+++ b/common/src/entities/device.rs
@@ -1,9 +1,10 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::Group;
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "devices")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/device.rs
+++ b/common/src/entities/device.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use super::Group;
+use super::{Group, Tenant};
 
 #[sea_orm::model]
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
@@ -13,6 +13,10 @@ pub struct Model {
     pub uuid: String,
 
     pub hostname: String,
+
+    pub tenant_id: i32,
+    #[sea_orm(belongs_to, from = "tenant_id", to = "id")]
+    pub tenant: HasOne<Tenant::Entity>,
 
     pub group_id: Option<i32>,
     #[sea_orm(belongs_to, from = "group_id", to = "id")]

--- a/common/src/entities/group.rs
+++ b/common/src/entities/group.rs
@@ -1,9 +1,10 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::Device;
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "groups")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/group.rs
+++ b/common/src/entities/group.rs
@@ -1,5 +1,6 @@
-use crate::entities::Device;
 use sea_orm::entity::prelude::*;
+
+use super::Device;
 
 #[sea_orm::model]
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -11,7 +12,7 @@ pub struct Model {
     pub name: String,
 
     #[sea_orm(has_many)]
-    pub device: HasMany<Device::Entity>,
+    pub devices: HasMany<Device::Entity>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/common/src/entities/os_assignment.rs
+++ b/common/src/entities/os_assignment.rs
@@ -26,19 +26,17 @@ pub struct Model {
 
 #[async_trait::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    async fn before_save<C>(
-        self,
-        _db: &C,
-        _insert: bool,
-    ) -> Result<Self, DbErr>
+    async fn before_save<C>(self, _db: &C, _insert: bool) -> Result<Self, DbErr>
     where
         C: ConnectionTrait,
     {
         let has_device = matches!(self.device_id.clone(), ActiveValue::Set(Some(_)));
-        let has_group  = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
+        let has_group = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
 
         if !has_device && !has_group {
-            return Err(DbErr::Custom("Either device_id or group_id must be set".into()));
+            return Err(DbErr::Custom(
+                "Either device_id or group_id must be set".into()
+            ));
         }
 
         Ok(self)

--- a/common/src/entities/os_assignment.rs
+++ b/common/src/entities/os_assignment.rs
@@ -35,7 +35,7 @@ impl ActiveModelBehavior for ActiveModel {
 
         if !has_device && !has_group {
             return Err(DbErr::Custom(
-                "Either device_id or group_id must be set".into()
+                "Either device_id or group_id must be set".into(),
             ));
         }
 

--- a/common/src/entities/os_assignment.rs
+++ b/common/src/entities/os_assignment.rs
@@ -1,10 +1,11 @@
 use sea_orm::ActiveValue;
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::{Device, Group, OsVersion};
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "os_assignments")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/os_assignment.rs
+++ b/common/src/entities/os_assignment.rs
@@ -1,0 +1,44 @@
+use sea_orm::entity::prelude::*;
+
+use super::{Device, Group, OsVersion};
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "os_assignments")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+
+    pub os_version_id: i32,
+    #[sea_orm(belongs_to, from = "os_version_id", to = "id")]
+    pub os_version: HasOne<OsVersion::Entity>,
+
+    pub device_id: Option<i32>,
+    #[sea_orm(belongs_to, from = "device_id", to = "id")]
+    pub device: HasOne<Device::Entity>,
+
+    pub group_id: Option<i32>,
+    #[sea_orm(belongs_to, from = "group_id", to = "id")]
+    pub group: HasOne<Group::Entity>,
+}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(
+        self,
+        _db: &C,
+        _insert: bool,
+    ) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let has_device = self.device_id.clone().into_value().is_some();
+        let has_group = self.group_id.clone().into_value().is_some();
+
+        if !has_device && !has_group {
+            return Err(DbErr::Custom("Either device_id or group_id must be set".into()));
+        }
+
+        Ok(self)
+    }
+}

--- a/common/src/entities/os_assignment.rs
+++ b/common/src/entities/os_assignment.rs
@@ -1,3 +1,4 @@
+use sea_orm::ActiveValue;
 use sea_orm::entity::prelude::*;
 
 use super::{Device, Group, OsVersion};
@@ -32,8 +33,8 @@ impl ActiveModelBehavior for ActiveModel {
     where
         C: ConnectionTrait,
     {
-        let has_device = self.device_id.clone().into_value().is_some();
-        let has_group = self.group_id.clone().into_value().is_some();
+        let has_device = matches!(self.device_id.clone(), ActiveValue::Set(Some(_)));
+        let has_group  = matches!(self.group_id.clone(), ActiveValue::Set(Some(_)));
 
         if !has_device && !has_group {
             return Err(DbErr::Custom("Either device_id or group_id must be set".into()));

--- a/common/src/entities/os_version.rs
+++ b/common/src/entities/os_version.rs
@@ -1,21 +1,17 @@
 use sea_orm::entity::prelude::*;
 
-use super::Group;
-
 #[sea_orm::model]
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
-#[sea_orm(table_name = "devices")]
+#[sea_orm(table_name = "os_versions")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]
     pub id: i32,
 
-    pub uuid: String,
+    pub commit_hash: String,
 
-    pub hostname: String,
+    pub orchestrator_version: String,
 
-    pub group_id: Option<i32>,
-    #[sea_orm(belongs_to, from = "group_id", to = "id")]
-    pub group: HasOne<Group::Entity>,
+    pub description: Option<String>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/common/src/entities/os_version.rs
+++ b/common/src/entities/os_version.rs
@@ -1,7 +1,8 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
 #[sea_orm::model]
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "os_versions")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = true)]

--- a/common/src/entities/tenant.rs
+++ b/common/src/entities/tenant.rs
@@ -1,0 +1,21 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::Device;
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "tenants")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+
+    pub name: String,
+
+    pub description: Option<String>,
+
+    #[sea_orm(has_many)]
+    pub devices: HasMany<Device::Entity>,
+}
+
+impl ActiveModelBehavior for ActiveModel {}


### PR DESCRIPTION
## Summary
Introduces the database schema to use as a first productive version. Using sea-orm and serde, automatic json (un-)marshalling to/from the ORM models is possible for easy API integration.

For json handling, see the tests in *db.rs* or the (very good) sea orm docs: https://www.sea-ql.org/SeaORM/docs/basic-crud/json/

## Related Issue
Closes #62


## Changes
- introduced more entitities to *common/entities*
- added necessary annotations to allow automatic json (de)serialization via serde

## How to Test
Run the `cargo test` command in the api server package. This tests entity creation and rough json functionality.

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
