### PR TITLE
fix: add database entities for reporting running app/os version

### DIFF
--- a/api-mock-server/src/db_migration.rs
+++ b/api-mock-server/src/db_migration.rs
@@ -2,13 +2,17 @@ pub use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::{EntityTrait, Schema};
 
 mod m20220101_000001_create_table;
+mod m20260523_000001_add_reported_assignments;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220101_000001_create_table::Migration)]
+        vec![
+            Box::new(m20220101_000001_create_table::Migration),
+            Box::new(m20260523_000001_add_reported_assignments::Migration),
+        ]
     }
 }
 

--- a/api-mock-server/src/db_migration/m20260523_000001_add_reported_assignments.rs
+++ b/api-mock-server/src/db_migration/m20260523_000001_add_reported_assignments.rs
@@ -1,0 +1,26 @@
+use sea_orm::Schema;
+use sea_orm_migration::prelude::*;
+
+use amos_common::entities;
+
+use super::create_table;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let schema = Schema::new(manager.get_database_backend());
+
+        create_table(manager, &schema, entities::ReportedApplicationAssignment::Entity).await?;
+        create_table(manager, &schema, entities::ReportedOsAssignment::Entity).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        _ = manager;
+        todo!();
+    }
+}

--- a/api-mock-server/src/db_migration/m20260523_000001_add_reported_assignments.rs
+++ b/api-mock-server/src/db_migration/m20260523_000001_add_reported_assignments.rs
@@ -13,7 +13,12 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let schema = Schema::new(manager.get_database_backend());
 
-        create_table(manager, &schema, entities::ReportedApplicationAssignment::Entity).await?;
+        create_table(
+            manager,
+            &schema,
+            entities::ReportedApplicationAssignment::Entity,
+        )
+        .await?;
         create_table(manager, &schema, entities::ReportedOsAssignment::Entity).await?;
 
         Ok(())

--- a/common/src/entities.rs
+++ b/common/src/entities.rs
@@ -19,5 +19,11 @@ pub use crate::entities::os_assignment as OsAssignment;
 pub mod os_version;
 pub use crate::entities::os_version as OsVersion;
 
+pub mod reported_application_assignment;
+pub use crate::entities::reported_application_assignment as ReportedApplicationAssignment;
+
+pub mod reported_os_assignment;
+pub use crate::entities::reported_os_assignment as ReportedOsAssignment;
+
 pub mod tenant;
 pub use crate::entities::tenant as Tenant;

--- a/common/src/entities/reported_application_assignment.rs
+++ b/common/src/entities/reported_application_assignment.rs
@@ -33,3 +33,21 @@ impl ActiveModelBehavior for ActiveModel {
         Ok(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ActiveModelTrait, sea_query::prelude::serde_json};
+    use serde_json::Value;
+
+    #[test]
+    fn app_assignment_update_doesnt_require_updated_at() {
+        let update_json_str = r#"{ "application_config_id": 5, "device_id": 3 }"#;
+        let update_json: Value = serde_json::from_str(update_json_str).unwrap();
+        println!("Unmarshalled: {:?}", update_json);
+
+        let app_ass_update = super::ActiveModel::from_json(update_json.clone());
+        println!("Loaded ActiveModel: {:?}", app_ass_update);
+
+        assert!(app_ass_update.is_ok());
+    }
+}

--- a/common/src/entities/reported_application_assignment.rs
+++ b/common/src/entities/reported_application_assignment.rs
@@ -1,0 +1,35 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::prelude::chrono;
+use serde::{Deserialize, Serialize};
+
+use super::{ApplicationConfig, Device};
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "reported_application_assignments")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+
+    pub application_config_id: i32,
+    #[sea_orm(belongs_to, from = "application_config_id", to = "id")]
+    pub application_config: HasOne<ApplicationConfig::Entity>,
+
+    pub device_id: i32,
+    #[sea_orm(belongs_to, from = "device_id", to = "id")]
+    pub device: HasOne<Device::Entity>,
+
+    pub updated_at: DateTimeUtc,
+}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        self.updated_at = Set(chrono::Utc::now());
+        Ok(self)
+    }
+}

--- a/common/src/entities/reported_os_assignment.rs
+++ b/common/src/entities/reported_os_assignment.rs
@@ -1,0 +1,35 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::prelude::chrono;
+use serde::{Deserialize, Serialize};
+
+use super::{Device, OsVersion};
+
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "reported_os_assignments")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = true)]
+    pub id: i32,
+
+    pub os_version_id: i32,
+    #[sea_orm(belongs_to, from = "os_version_id", to = "id")]
+    pub os_version: HasOne<OsVersion::Entity>,
+
+    pub device_id: i32,
+    #[sea_orm(belongs_to, from = "device_id", to = "id")]
+    pub device: HasOne<Device::Entity>,
+
+    pub updated_at: DateTimeUtc,
+}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        self.updated_at = Set(chrono::Utc::now());
+        Ok(self)
+    }
+}


### PR DESCRIPTION
## Summary
Introduces two newq tables to store the running app/os version reported by the orchestrators on the devices.

Good to know: On updates, there is a timestamp column which gets updated by the ORM automatically on insert/update. Just leave the `updated_at` attribute as `NotSet`.


## Related Issue
Arose from #55 


## Changes
- added db entities
- added migration

## How to Test
Run the api server, another migration (adding the tables) is executed

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [ ] I have added/updated tests (if applicable)
- [ ] I have updated documentation (if applicable)
