### PR TITLE
Feat/podman

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,7 @@
     "features": {
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "1.95.0"
-        },
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+        }
     },
 
     "onCreateCommand": ["/bin/sudo", "/bin/bash", ".devcontainer/install.sh"],
@@ -22,7 +21,7 @@
         },
         "amos": {
             // Update this marker when changing ./install.sh
-            "installScriptVersion": "2026-05-05 09:20"
+            "installScriptVersion": "2026-05-14 13:30"
         }
     }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   dev-container:
     image: mcr.microsoft.com/devcontainers/base:ubuntu-24.04

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: mcr.microsoft.com/devcontainers/base:ubuntu-24.04
     volumes:
       - ../..:/workspaces:cached
+      - podman-containers:/home/vscode/.local/share/containers
+    privileged: true # Needed for podman
     command: sleep infinity
 
   mock-api-container:
@@ -12,3 +14,6 @@ services:
       context: ..
       dockerfile: .devcontainer/mock-api.Dockerfile
     restart: unless-stopped
+
+volumes:
+  podman-containers:

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -25,6 +25,9 @@ export DEBIAN_FRONTEND=noninteractive
 # This script runs when the container gets built
 # Use it e.g. to install additional packages from apt:
 #
-# apt-get update -y
-# apt-get install -y --no-install-recommends htop
-# rm -rf /var/lib/apt/lists/*
+apt-get update -y
+apt-get install -y --no-install-recommends podman fuse-overlayfs uidmap slirp4netns
+rm -rf /var/lib/apt/lists/*
+
+# Needed for podman to start rootless containers
+chown vscode /home/vscode/.local/share/containers

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
+.devcontainer/
+.github/
+Deliverables/
+Documentation/
 target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,11 @@ name = "amos-orchestrator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "config",
  "env_logger",
+ "futures",
  "log",
  "serde",
  "serde_json",
@@ -638,12 +640,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -687,6 +704,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = "0.1"
 clap = { version = "4.6.1", features = ["derive"] }
 config = { version = "0.15.22", features = ["toml"] }
 env_logger = "0.11.10"
+futures = { version = "0.3", features = ["std"], default-features = false }
 log = "0.4.29"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["full"] }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -13,6 +13,7 @@ mod apps;
 mod healthcheck;
 mod inventory;
 mod os_tree;
+mod podman;
 mod state;
 use std::env;
 use std::path::PathBuf;

--- a/orchestrator/src/podman.rs
+++ b/orchestrator/src/podman.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::BTreeMap,
-    error::Error,
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::Mutex,
@@ -23,13 +22,13 @@ static INSTANCE: Mutex<Option<Podman<RealPodmanRunner>>> = Mutex::new(Option::So
     phantom: PhantomData,
 }));
 
-struct Podman<R: PodmanRunner> {
+pub struct Podman<R: PodmanRunner> {
     version_cache: BTreeMap<String, String>,
     phantom: PhantomData<R>,
 }
 
 #[async_trait::async_trait]
-trait PodmanRunner {
+pub trait PodmanRunner {
     async fn run_podman(args: &[&str]) -> PodmanErr<Vec<u8>>;
     async fn try_write_version(item: &ComposeLsResultItem, ver: &str) -> PodmanErr<()>;
     async fn try_read_version(item: &ComposeLsResultItem) -> PodmanErr<String>;
@@ -46,7 +45,7 @@ impl Podman<RealPodmanRunner> {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct ComposeLsResultItem<'a> {
+pub struct ComposeLsResultItem<'a> {
     name: &'a str,
     status: &'a str,
     config_files: &'a str,
@@ -139,7 +138,7 @@ impl<R: PodmanRunner> Podman<R> {
         })()
         .await
         {
-            log::info!("Failed to save stack version: {e}");
+            log::warn!("Failed to save stack version: {e}");
         }
 
         self.version_cache.insert(id.clone(), version.clone());
@@ -153,7 +152,7 @@ impl<R: PodmanRunner> Podman<R> {
     }
 
     // Remove stopped containers, unused images, volumes and cache entries
-    pub async fn cleanup<'a>(&'a mut self) -> PodmanErr<()> {
+    pub async fn prune<'a>(&'a mut self) -> PodmanErr<()> {
         R::run_podman(&["system", "prune", "--all", "--force", "--volumes"]).await?;
 
         // Compose cache needs some extra attention
@@ -193,10 +192,10 @@ impl<R: PodmanRunner> Podman<R> {
             }
         }
 
-        println!("Deletion list: {:?}", deletion_list);
         for item in deletion_list {
-            // Treat deletion failures as non-fatal
-            let _ = tokio::fs::remove_dir_all(&item).await;
+            if let Err(e) = tokio::fs::remove_dir_all(&item).await {
+                log::warn!("Failed to delete stale Compose cache folder: {e}");
+            }
         }
 
         Ok(())
@@ -204,10 +203,10 @@ impl<R: PodmanRunner> Podman<R> {
 }
 
 #[derive(Clone, Copy)]
-struct StackSource<'a>(&'a str);
+pub struct StackSource<'a>(&'a str);
 
 impl<'a> StackSource<'a> {
-    pub fn new(source: &'a str) -> Result<Self, Box<dyn Error>> {
+    pub fn new(source: &'a str) -> PodmanErr<Self> {
         if !source.starts_with("oci://") {
             Err("Only compose files from OCI registries supported (oci://...)".into())
         } else if source.ends_with("latest") {
@@ -218,15 +217,15 @@ impl<'a> StackSource<'a> {
     }
 }
 
-struct PodmanStack<'a, R: PodmanRunner> {
+pub struct PodmanStack<'a, R: PodmanRunner> {
     id: String,
     status: PodmanStackStatus,
     version: Option<String>,
     phantom: PhantomData<(&'a (), R)>,
 }
 
-#[derive(PartialEq, Eq, Debug)]
-enum PodmanStackStatus {
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum PodmanStackStatus {
     Stopped,
     Ambiguous,
     Running,
@@ -249,9 +248,19 @@ impl<'a, R: PodmanRunner> PodmanStack<'a, R> {
         R::run_podman(&["compose", "-p", &self.id, "down", "--timeout", "30"]).await?;
         Ok(())
     }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn status(&self) -> PodmanStackStatus {
+        self.status
+    }
+    pub fn version(&self) -> &Option<String> {
+        &self.version
+    }
 }
 
-struct RealPodmanRunner;
+pub struct RealPodmanRunner;
 
 impl RealPodmanRunner {
     fn infer_version_file_path(ls_item: &ComposeLsResultItem) -> PodmanErr<PathBuf> {

--- a/orchestrator/src/podman.rs
+++ b/orchestrator/src/podman.rs
@@ -4,7 +4,13 @@
 // This module mainly works using the "podman compose" CLI, and sources the files from an OCI registry
 // To remember the version of the respective stack, small marker files are kept in the docker compose cache
 
-use std::{collections::BTreeMap, error::Error, marker::PhantomData, path::Path, sync::Mutex};
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    marker::PhantomData,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 
 use serde::Deserialize;
 use tokio::{io::AsyncReadExt, process::Command};
@@ -13,18 +19,20 @@ type PodmanErr<R> = Result<R, Box<dyn std::error::Error>>;
 
 // Ensure only a single instance of this ever exists
 static INSTANCE: Mutex<Option<Podman<RealPodmanRunner>>> = Mutex::new(Option::Some(Podman {
-    runner: RealPodmanRunner,
     version_cache: BTreeMap::new(),
+    phantom: PhantomData,
 }));
 
 struct Podman<R: PodmanRunner> {
-    runner: R,
     version_cache: BTreeMap<String, String>,
+    phantom: PhantomData<R>,
 }
 
 #[async_trait::async_trait]
 trait PodmanRunner {
-    async fn run_podman(&mut self, args: &[&str]) -> PodmanErr<Vec<u8>>;
+    async fn run_podman(args: &[&str]) -> PodmanErr<Vec<u8>>;
+    async fn try_write_version(item: &ComposeLsResultItem, ver: &str) -> PodmanErr<()>;
+    async fn try_read_version(item: &ComposeLsResultItem) -> PodmanErr<String>;
 }
 
 impl Podman<RealPodmanRunner> {
@@ -36,22 +44,19 @@ impl Podman<RealPodmanRunner> {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ComposeLsResultItem<'a> {
+    name: &'a str,
+    status: &'a str,
+    config_files: &'a str,
+}
+
 impl<R: PodmanRunner> Podman<R> {
-    pub async fn stacks<'a>(&'a mut self) -> PodmanErr<Vec<PodmanStack<'a>>> {
-        let cmd_output = self
-            .runner
-            .run_podman(&["compose", "ls", "--all", "--format", "--json"])
-            .await?;
+    pub async fn stacks<'a>(&'a mut self) -> PodmanErr<Vec<PodmanStack<'a, R>>> {
+        let cmd_output = R::run_podman(&["compose", "ls", "--all", "--format", "json"]).await?;
 
-        #[derive(Deserialize)]
-        #[serde(rename_all = "PascalCase")]
-        struct ResultItem<'a> {
-            name: &'a str,
-            status: &'a str,
-            config_files: &'a str,
-        }
-
-        let mut cmd_items: Vec<ResultItem> = serde_json::from_slice(&cmd_output)?;
+        let mut cmd_items: Vec<ComposeLsResultItem> = serde_json::from_slice(&cmd_output)?;
         cmd_items.sort_by_key(|item| item.name); // Usually already sorted
 
         let output_futs = cmd_items.iter().map(async |item| {
@@ -61,37 +66,29 @@ impl<R: PodmanRunner> Podman<R> {
                 _ => PodmanStackStatus::Stopped,
             };
 
+            // Retrieve version from either cache or marker file
             let version = match self.version_cache.get(item.name) {
                 Some(v) => Some(v.to_owned()),
-                None => (async || -> PodmanErr<String> {
-                    // Try retrieving the stack version by looking in the compose cache folder
-                    let mut folders = item.config_files.split(',').map(|s| Path::new(s).parent());
-                    let config_folder = match folders.next() {
-                        Some(Some(first)) if folders.all(|x| x == Some(first)) => first,
-                        _ => return Err("Not sure about config folder".into()),
-                    };
-                    let path = config_folder.join("version");
-
-                    let file = tokio::fs::File::open(path).await?;
-                    let mut output = String::new();
-                    file.take(512).read_to_string(&mut output).await?;
-                    Ok(output)
-                })()
-                .await
-                .ok(),
+                None => R::try_read_version(item).await.ok(),
             };
 
             PodmanStack {
                 id: item.name.to_owned(),
                 status,
                 version,
-                lifetime: PhantomData,
+                phantom: PhantomData,
             }
         });
 
         let output = futures::future::join_all(output_futs).await;
 
-        // Remove old keys from the version cache
+        self.version_cache.extend(
+            output
+                .iter()
+                .filter_map(|ps| ps.version.to_owned().map(|v| (ps.id.to_owned(), v))),
+        );
+
+        // Remove old keys from the version cache, needs sorted items
         debug_assert!(output.len() <= self.version_cache.len());
         let mut ids = output.iter().map(|ps| ps.id.as_str()).peekable();
         self.version_cache.retain(|key, _| match ids.peek() {
@@ -106,10 +103,8 @@ impl<R: PodmanRunner> Podman<R> {
     }
 
     // Pre-download images to make create() run quicker
-    pub async fn pull<'a>(&mut self, source: StackSource<'a>) -> Result<(), Box<dyn Error>> {
-        self.runner
-            .run_podman(&["compose", "-f", source.0, "pull"])
-            .await?;
+    pub async fn pull<'a>(&mut self, source: StackSource<'a>) -> PodmanErr<()> {
+        R::run_podman(&["compose", "-f", source.0, "pull", "--quiet"]).await?;
         Ok(())
     }
 
@@ -119,14 +114,33 @@ impl<R: PodmanRunner> Podman<R> {
         id: String,
         source: StackSource<'b>,
         version: String,
-    ) -> Result<PodmanStack<'a>, Box<dyn Error>> {
+    ) -> PodmanErr<PodmanStack<'a, R>> {
         if self.version_cache.contains_key(&id) {
             return Err("Stack with this ID already exists, consider destroying it first".into());
         }
 
-        self.runner
-            .run_podman(&["compose", "-p", &id, "-f", source.0, "create"])
-            .await?;
+        #[rustfmt::skip]
+        R::run_podman(&["compose", "-p", &id, "-f", source.0, "create",
+            "--quiet-pull", "--no-build", "--yes"]).await?;
+
+        // Try saving the stack version to the compose cache folder
+        if let Err(e) = (async || -> PodmanErr<()> {
+            #[rustfmt::skip]
+            let ls_output = R::run_podman(&["compose", "ls",
+                "--all", "--format", "json", "--filter", &format!("name=^{id}$")]).await?;
+            let ls_items: Vec<ComposeLsResultItem> = serde_json::from_slice(&ls_output)?;
+
+            if ls_items.len() != 1 {
+                return Err("Stack not found".into());
+            }
+
+            R::try_write_version(&ls_items[0], &version).await?;
+            Ok(())
+        })()
+        .await
+        {
+            log::info!("Failed to save stack version: {e}");
+        }
 
         self.version_cache.insert(id.clone(), version.clone());
 
@@ -134,8 +148,58 @@ impl<R: PodmanRunner> Podman<R> {
             id,
             status: PodmanStackStatus::Stopped,
             version: Some(version),
-            lifetime: PhantomData,
+            phantom: PhantomData,
         })
+    }
+
+    // Remove stopped containers, unused images, volumes and cache entries
+    pub async fn cleanup<'a>(&'a mut self) -> PodmanErr<()> {
+        R::run_podman(&["system", "prune", "--all", "--force", "--volumes"]).await?;
+
+        // Compose cache needs some extra attention
+        let ls_output = R::run_podman(&["compose", "ls", "--all", "--format", "json"]).await?;
+        let ls_items: Vec<ComposeLsResultItem> = serde_json::from_slice(&ls_output)?;
+
+        let (base_dirs, mut ids): (Vec<_>, Vec<_>) = ls_items
+            .iter()
+            .map(|item| item.config_files.split(','))
+            .flatten()
+            .filter_map(|file_path| Path::new(file_path.trim()).parent())
+            .filter_map(|p| match (p.parent(), p.file_name()) {
+                (Some(x), Some(y)) => Some((x, y)),
+                _ => None,
+            })
+            .unzip();
+
+        if base_dirs.len() == 0 {
+            return Ok(());
+        }
+
+        let cache_dir_path = base_dirs[0].canonicalize()?;
+        if cache_dir_path.components().count() < 3 || base_dirs.iter().any(|&x| x != base_dirs[0]) {
+            return Err(
+                format!("Not sure about Compose cache folder ({:?})", cache_dir_path).into(),
+            );
+        }
+
+        ids.sort();
+
+        let mut cache_dir = tokio::fs::read_dir(&cache_dir_path).await?;
+        let mut deletion_list = Vec::new();
+        while let Ok(Some(d)) = cache_dir.next_entry().await {
+            if ids.binary_search(&d.file_name().as_os_str()).is_err() {
+                // Cache folder has no reference from a Compose stack
+                deletion_list.push(d.path());
+            }
+        }
+
+        println!("Deletion list: {:?}", deletion_list);
+        for item in deletion_list {
+            // Treat deletion failures as non-fatal
+            let _ = tokio::fs::remove_dir_all(&item).await;
+        }
+
+        Ok(())
     }
 }
 
@@ -154,11 +218,11 @@ impl<'a> StackSource<'a> {
     }
 }
 
-struct PodmanStack<'a> {
+struct PodmanStack<'a, R: PodmanRunner> {
     id: String,
     status: PodmanStackStatus,
     version: Option<String>,
-    lifetime: PhantomData<&'a ()>,
+    phantom: PhantomData<(&'a (), R)>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -168,19 +232,44 @@ enum PodmanStackStatus {
     Running,
 }
 
-impl<'a> PodmanStack<'a> {
-    pub async fn start(&mut self) {}
+impl<'a, R: PodmanRunner> PodmanStack<'a, R> {
+    pub async fn start(&mut self) -> PodmanErr<()> {
+        #[rustfmt::skip]
+        R::run_podman(&["compose", "-p", &self.id, "start",
+            "--wait", "--wait-timeout", "30"]).await?;
+        Ok(())
+    }
 
-    pub async fn stop(&mut self) {}
+    pub async fn stop(&mut self) -> PodmanErr<()> {
+        R::run_podman(&["compose", "-p", &self.id, "stop", "--timeout", "30"]).await?;
+        Ok(())
+    }
 
-    pub async fn destroy(self) {}
+    pub async fn destroy(self) -> PodmanErr<()> {
+        R::run_podman(&["compose", "-p", &self.id, "down", "--timeout", "30"]).await?;
+        Ok(())
+    }
 }
 
 struct RealPodmanRunner;
 
+impl RealPodmanRunner {
+    fn infer_version_file_path(ls_item: &ComposeLsResultItem) -> PodmanErr<PathBuf> {
+        let mut folders = ls_item
+            .config_files
+            .split(',')
+            .map(|s| Path::new(s).parent());
+        let config_folder = match folders.next() {
+            Some(Some(first)) if folders.all(|x| x == Some(first)) => first,
+            _ => return Err("Not sure about config folder".into()),
+        };
+        Ok(config_folder.join("version"))
+    }
+}
+
 #[async_trait::async_trait]
 impl PodmanRunner for RealPodmanRunner {
-    async fn run_podman(&mut self, args: &[&str]) -> PodmanErr<Vec<u8>> {
+    async fn run_podman(args: &[&str]) -> PodmanErr<Vec<u8>> {
         match Command::new("/bin/podman").args(args).output().await {
             Err(_) => Err(Box::from("Could not find Podman CLI")),
             Ok(o) if !o.status.success() => Err(match String::from_utf8(o.stderr) {
@@ -190,30 +279,57 @@ impl PodmanRunner for RealPodmanRunner {
             Ok(o) => Ok(o.stdout),
         }
     }
+
+    async fn try_write_version(item: &ComposeLsResultItem, ver: &str) -> PodmanErr<()> {
+        let path = Self::infer_version_file_path(item)?;
+        tokio::fs::write(path, ver.as_bytes()).await?;
+        Ok(())
+    }
+
+    async fn try_read_version(item: &ComposeLsResultItem) -> PodmanErr<String> {
+        // Try retrieving the stack version by looking in the compose cache folder
+        let path = Self::infer_version_file_path(item)?;
+        let file = tokio::fs::File::open(path).await?;
+        let mut output = String::new();
+        file.take(512).read_to_string(&mut output).await?;
+        Ok(output)
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, marker::PhantomData};
 
     struct MockPodmanRunner;
 
     #[async_trait::async_trait]
     impl super::PodmanRunner for MockPodmanRunner {
-        async fn run_podman(&mut self, args: &[&str]) -> super::PodmanErr<Vec<u8>> {
+        async fn run_podman(args: &[&str]) -> super::PodmanErr<Vec<u8>> {
             println!("Running podman {:?}", args);
             match args {
-                ["compose", .., "create"] => Ok(Vec::new()),
-                _ => Err("Unknown command".into())
+                ["compose", "ls", ..] => Ok(r#"[{"Name":"bbbb","Status":"created(13), exited(2)","ConfigFiles":"/test/compose.yaml"},{"Name":"aaaa","Status":"running(13)","ConfigFiles":"/test/compose.yaml"}]"#.into()),
+                ["compose", ..] if args.contains(&"create") => Ok(Vec::new()),
+                _ => Err("Unknown command".into()),
             }
+        }
+
+        async fn try_write_version(
+            _item: &super::ComposeLsResultItem,
+            _ver: &str,
+        ) -> super::PodmanErr<()> {
+            Ok(())
+        }
+
+        async fn try_read_version(_item: &super::ComposeLsResultItem) -> super::PodmanErr<String> {
+            Ok("1.2.3".to_owned())
         }
     }
 
     #[tokio::test]
-    async fn test_stacks_create() {
-        let mut podman = super::Podman {
-            runner: MockPodmanRunner,
+    async fn test_stack_create() {
+        let mut podman: super::Podman<MockPodmanRunner> = super::Podman {
             version_cache: BTreeMap::new(),
+            phantom: PhantomData,
         };
 
         let stack = podman
@@ -226,7 +342,68 @@ mod test {
             .unwrap();
 
         assert_eq!(stack.id, "test");
-        assert_eq!(stack.version, Some("1.2.3".to_owned()));
+        assert_eq!(stack.version.unwrap(), "1.2.3");
         assert_eq!(stack.status, super::PodmanStackStatus::Stopped);
+
+        let (k, v) = podman.version_cache.first_key_value().unwrap();
+        assert_eq!(k, "test");
+        assert_eq!(v, "1.2.3");
+    }
+
+    #[tokio::test]
+    async fn test_stack_list() {
+        let mut podman: super::Podman<MockPodmanRunner> = super::Podman {
+            version_cache: BTreeMap::new(),
+            phantom: PhantomData,
+        };
+        podman
+            .version_cache
+            .insert("bbbb".to_owned(), "test".to_owned());
+
+        let stacks = podman.stacks().await.unwrap();
+        assert_eq!(stacks.len(), 2);
+
+        assert_eq!(stacks[0].id, "aaaa");
+        assert_eq!(stacks[0].version.as_ref().unwrap(), "1.2.3");
+        assert_eq!(stacks[0].status, super::PodmanStackStatus::Running);
+
+        assert_eq!(stacks[1].id, "bbbb");
+        assert_eq!(stacks[1].version.as_ref().unwrap(), "test");
+        assert_eq!(stacks[1].status, super::PodmanStackStatus::Ambiguous);
+
+        assert_eq!(podman.version_cache.len(), 2)
+    }
+
+    #[tokio::test]
+    #[ignore = "Must have Podman + Compose installed and completely clean"]
+    async fn test_real_pull_create() {
+        let mut p = super::Podman::take().unwrap();
+        let test_source =
+            super::StackSource::new("oci://docker.io/openvidu/local-meet:3.7.0").unwrap();
+
+        assert_eq!(p.stacks().await.unwrap().len(), 0, "Please clean env");
+
+        p.pull(test_source).await.unwrap();
+        assert_eq!(p.stacks().await.unwrap().len(), 0);
+        assert_eq!(p.version_cache.len(), 0);
+
+        let stack = p
+            .create("ccc".to_owned(), test_source, "1".to_owned())
+            .await
+            .unwrap();
+        assert_eq!(stack.id, "ccc");
+        assert_eq!(stack.status, super::PodmanStackStatus::Stopped);
+        assert_eq!(stack.version.unwrap(), "1");
+        assert_eq!(p.version_cache.len(), 1);
+
+        let mut stacks = p.stacks().await.unwrap();
+        assert_eq!(stacks.len(), 1);
+        assert_eq!(stacks[0].id, "ccc");
+        assert_eq!(stacks[0].status, super::PodmanStackStatus::Stopped);
+
+        stacks.pop().unwrap().destroy().await.unwrap();
+
+        assert_eq!(p.stacks().await.unwrap().len(), 0);
+        assert_eq!(p.version_cache.len(), 0);
     }
 }

--- a/orchestrator/src/podman.rs
+++ b/orchestrator/src/podman.rs
@@ -1,0 +1,232 @@
+// Control Podman
+// This assumes full ownership of the Podman instance
+
+// This module mainly works using the "podman compose" CLI, and sources the files from an OCI registry
+// To remember the version of the respective stack, small marker files are kept in the docker compose cache
+
+use std::{collections::BTreeMap, error::Error, marker::PhantomData, path::Path, sync::Mutex};
+
+use serde::Deserialize;
+use tokio::{io::AsyncReadExt, process::Command};
+
+type PodmanErr<R> = Result<R, Box<dyn std::error::Error>>;
+
+// Ensure only a single instance of this ever exists
+static INSTANCE: Mutex<Option<Podman<RealPodmanRunner>>> = Mutex::new(Option::Some(Podman {
+    runner: RealPodmanRunner,
+    version_cache: BTreeMap::new(),
+}));
+
+struct Podman<R: PodmanRunner> {
+    runner: R,
+    version_cache: BTreeMap<String, String>,
+}
+
+#[async_trait::async_trait]
+trait PodmanRunner {
+    async fn run_podman(&mut self, args: &[&str]) -> PodmanErr<Vec<u8>>;
+}
+
+impl Podman<RealPodmanRunner> {
+    pub fn take() -> PodmanErr<Self> {
+        INSTANCE
+            .lock()?
+            .take()
+            .ok_or("Cannot create multiple Podman instances".into())
+    }
+}
+
+impl<R: PodmanRunner> Podman<R> {
+    pub async fn stacks<'a>(&'a mut self) -> PodmanErr<Vec<PodmanStack<'a>>> {
+        let cmd_output = self
+            .runner
+            .run_podman(&["compose", "ls", "--all", "--format", "--json"])
+            .await?;
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct ResultItem<'a> {
+            name: &'a str,
+            status: &'a str,
+            config_files: &'a str,
+        }
+
+        let mut cmd_items: Vec<ResultItem> = serde_json::from_slice(&cmd_output)?;
+        cmd_items.sort_by_key(|item| item.name); // Usually already sorted
+
+        let output_futs = cmd_items.iter().map(async |item| {
+            let status = match item.status {
+                s if s.contains(',') => PodmanStackStatus::Ambiguous,
+                s if s.starts_with("running") => PodmanStackStatus::Running,
+                _ => PodmanStackStatus::Stopped,
+            };
+
+            let version = match self.version_cache.get(item.name) {
+                Some(v) => Some(v.to_owned()),
+                None => (async || -> PodmanErr<String> {
+                    // Try retrieving the stack version by looking in the compose cache folder
+                    let mut folders = item.config_files.split(',').map(|s| Path::new(s).parent());
+                    let config_folder = match folders.next() {
+                        Some(Some(first)) if folders.all(|x| x == Some(first)) => first,
+                        _ => return Err("Not sure about config folder".into()),
+                    };
+                    let path = config_folder.join("version");
+
+                    let file = tokio::fs::File::open(path).await?;
+                    let mut output = String::new();
+                    file.take(512).read_to_string(&mut output).await?;
+                    Ok(output)
+                })()
+                .await
+                .ok(),
+            };
+
+            PodmanStack {
+                id: item.name.to_owned(),
+                status,
+                version,
+                lifetime: PhantomData,
+            }
+        });
+
+        let output = futures::future::join_all(output_futs).await;
+
+        // Remove old keys from the version cache
+        debug_assert!(output.len() <= self.version_cache.len());
+        let mut ids = output.iter().map(|ps| ps.id.as_str()).peekable();
+        self.version_cache.retain(|key, _| match ids.peek() {
+            Some(s) if s == key => {
+                ids.next();
+                true
+            }
+            _ => false,
+        });
+
+        Ok(output)
+    }
+
+    // Pre-download images to make create() run quicker
+    pub async fn pull<'a>(&mut self, source: StackSource<'a>) -> Result<(), Box<dyn Error>> {
+        self.runner
+            .run_podman(&["compose", "-f", source.0, "pull"])
+            .await?;
+        Ok(())
+    }
+
+    // Create a new stack, start it with start()
+    pub async fn create<'a, 'b>(
+        &'a mut self,
+        id: String,
+        source: StackSource<'b>,
+        version: String,
+    ) -> Result<PodmanStack<'a>, Box<dyn Error>> {
+        if self.version_cache.contains_key(&id) {
+            return Err("Stack with this ID already exists, consider destroying it first".into());
+        }
+
+        self.runner
+            .run_podman(&["compose", "-p", &id, "-f", source.0, "create"])
+            .await?;
+
+        self.version_cache.insert(id.clone(), version.clone());
+
+        Ok(PodmanStack {
+            id,
+            status: PodmanStackStatus::Stopped,
+            version: Some(version),
+            lifetime: PhantomData,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct StackSource<'a>(&'a str);
+
+impl<'a> StackSource<'a> {
+    pub fn new(source: &'a str) -> Result<Self, Box<dyn Error>> {
+        if !source.starts_with("oci://") {
+            Err("Only compose files from OCI registries supported (oci://...)".into())
+        } else if source.ends_with("latest") {
+            Err("Please use a specific version instead of latest".into())
+        } else {
+            Ok(Self(source))
+        }
+    }
+}
+
+struct PodmanStack<'a> {
+    id: String,
+    status: PodmanStackStatus,
+    version: Option<String>,
+    lifetime: PhantomData<&'a ()>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum PodmanStackStatus {
+    Stopped,
+    Ambiguous,
+    Running,
+}
+
+impl<'a> PodmanStack<'a> {
+    pub async fn start(&mut self) {}
+
+    pub async fn stop(&mut self) {}
+
+    pub async fn destroy(self) {}
+}
+
+struct RealPodmanRunner;
+
+#[async_trait::async_trait]
+impl PodmanRunner for RealPodmanRunner {
+    async fn run_podman(&mut self, args: &[&str]) -> PodmanErr<Vec<u8>> {
+        match Command::new("/bin/podman").args(args).output().await {
+            Err(_) => Err(Box::from("Could not find Podman CLI")),
+            Ok(o) if !o.status.success() => Err(match String::from_utf8(o.stderr) {
+                Ok(msg) => Box::from(format!("Podman error: {}", msg)),
+                _ => Box::from("Podman returned an error"),
+            }),
+            Ok(o) => Ok(o.stdout),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    struct MockPodmanRunner;
+
+    #[async_trait::async_trait]
+    impl super::PodmanRunner for MockPodmanRunner {
+        async fn run_podman(&mut self, args: &[&str]) -> super::PodmanErr<Vec<u8>> {
+            println!("Running podman {:?}", args);
+            match args {
+                ["compose", .., "create"] => Ok(Vec::new()),
+                _ => Err("Unknown command".into())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stacks_create() {
+        let mut podman = super::Podman {
+            runner: MockPodmanRunner,
+            version_cache: BTreeMap::new(),
+        };
+
+        let stack = podman
+            .create(
+                "test".to_owned(),
+                super::StackSource::new("oci://test:test").unwrap(),
+                "1.2.3".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(stack.id, "test");
+        assert_eq!(stack.version, Some("1.2.3".to_owned()));
+        assert_eq!(stack.status, super::PodmanStackStatus::Stopped);
+    }
+}


### PR DESCRIPTION
## Summary
- Manages applications in Podman using Compose
- Can handle Pulling, Creating, Starting, Stopping, Destroying and Cleanup

## Related Issue
Closes #21 

## Changes
- Added podman.rs to Orchestrator

## How to Test
- Run normal Unit tests
- Install Podman and Docker-Compose and run cargo test -- --ignored

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
