### PR TITLE
feat(bootc): build multi-arch (amd64+arm64) image

### DIFF
--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,7 +57,7 @@ jobs:
         with:
           context: .
           file: rootc-build/Containerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,8 +61,10 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
+ "serde_json",
  "serial_test",
  "tokio",
+ "tower",
  "tower-http",
 ]
 
@@ -420,6 +422,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -435,6 +438,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",

--- a/Documentation/build_documentation.md
+++ b/Documentation/build_documentation.md
@@ -273,6 +273,26 @@ podman tag amos-orchestrator:latest ghcr.io/amosproj/amos2026ss01-zero-downtime-
 podman push ghcr.io/amosproj/amos2026ss01-zero-downtime-linux-updates-system:latest
 ```
 
+### Building for ARM (Apple Silicon)
+
+The `Containerfile` cross-compiles the orchestrator binary based on the build platform, so an `arm64` image can be produced on any host (including an x86 CI runner). The `linux/arm64` final stage pulls the matching `quay.io/fedora/fedora-bootc` variant automatically.
+
+To build and run locally on a Mac with `podman-bootc`:
+
+```bash
+# Build an arm64 image
+podman build --platform=linux/arm64 \
+  -f rootc-build/Containerfile \
+  -t amos-orchestrator-arm64:local .
+
+# Boot it in a VM
+podman-bootc run --filesystem=ext4 amos-orchestrator-arm64:local
+```
+
+The release CI workflow (`container-orchestrator.yml`) builds and pushes a multi-arch manifest list (`linux/amd64` + `linux/arm64`) on every tag, so `podman-bootc run --filesystem=ext4 ghcr.io/amosproj/amos2026ss01-zero-downtime-linux-updates-system:<tag>` works on both Linux/x86 and Apple Silicon once the tag has been published with multi-arch support.
+
+> **Note:** Existing tags pushed before multi-arch was added (e.g. `mid-project-release-candidate`) are amd64-only. Either build locally with the recipe above, or have a maintainer delete and re-push the tag to trigger a multi-arch rebuild.
+
 ---
 
 ## CI / CD

--- a/rootc-build/Containerfile
+++ b/rootc-build/Containerfile
@@ -1,14 +1,30 @@
-# Compile the orchestrator binary
-FROM rust:1.95-slim AS builder
+# Compile the orchestrator binary on the BUILD arch, target the IMAGE arch
+FROM --platform=$BUILDPLATFORM rust:1.95-slim AS builder
+ARG TARGETARCH
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) RUST_TARGET=x86_64-unknown-linux-gnu;  PKG=gcc-x86-64-linux-gnu  ;; \
+      arm64) RUST_TARGET=aarch64-unknown-linux-gnu; PKG=gcc-aarch64-linux-gnu ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    echo "$RUST_TARGET" > /rust-target; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends "$PKG"; \
+    rm -rf /var/lib/apt/lists/*; \
+    rustup target add "$RUST_TARGET"
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 COPY . /workspace
 WORKDIR /workspace
-RUN cargo build --package amos-orchestrator --release
+RUN RUST_TARGET="$(cat /rust-target)"; \
+    cargo build --package amos-orchestrator --release --target "$RUST_TARGET"; \
+    cp "target/$RUST_TARGET/release/amos-orchestrator" /amos-orchestrator
 
-# Bootable OS image (fedora-bootc)
+# Bootable OS image (fedora-bootc) — resolves to the matching arch automatically
 FROM quay.io/fedora/fedora-bootc:latest
 
 # Copy the compiled binary from the build stage
-COPY --from=builder /workspace/target/release/amos-orchestrator /usr/local/bin/amos-orchestrator
+COPY --from=builder /amos-orchestrator /usr/local/bin/amos-orchestrator
 
 # Install the systemd unit and enable it
 COPY rootc-build/orchestrator.service /etc/systemd/system/orchestrator.service


### PR DESCRIPTION
  - cross-compile orchestrator bin in bootc image to arm64
  - CI workflow now sets up QEMU (only needed for the dnf step on arm64) and pushes a multi-arch manifest list on tagged builds.
  - Docs: recipe for building locally for Apple Silicon and using podman-bootc

## Summary
<!-- What does this PR do? Keep it to 2-3 sentences. -->


## Related Issue
<!-- Link the issue this PR addresses. Use a keyword to auto-close it on merge: -->
<!-- Fixes #123  /  Closes #123  /  Refs #123 -->


## Changes
<!-- List the key changes as bullet points -->
-

## How to Test
<!-- Steps for a reviewer to verify this works -->
1.

## Checklist
- [ ] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [ ] I have added/updated tests (if applicable)
- [ ] I have updated documentation (if applicable)
