### PR TITLE
feat: make fedora version dynamic in orchestrator build

### DIFF
--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+workflow_dispatch:
+  inputs:
+    fedora_version:
+      description: 'Fedora version to build with (e.g. 39, 40, latest)'
+      required: true
+      default: 'latest'
+      type: string
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-system
@@ -27,7 +35,7 @@ jobs:
 
       # Log in to GHCR – only on main branch or tags, never on feature branches or PRs
       - name: Log in to GitHub Container Registry
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -46,6 +54,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
             type=sha
+            type=raw,value=${{ inputs.fedora_version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -53,9 +62,11 @@ jobs:
           context: .
           file: rootc-build/Containerfile
           platforms: linux/amd64
-          push: ${{ github.ref_type == 'tag' }}
+          push: ${{ github.ref_type == 'tag' }} || github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FEDORA_VERSION=${{ inputs.fedora_version || 'latest' }}
           # Cache layers in the GitHub Actions cache to speed up subsequent builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -62,7 +62,7 @@ jobs:
           context: .
           file: rootc-build/Containerfile
           platforms: linux/amd64
-          push: ${{ github.ref_type == 'tag' }} || github.event_name == 'workflow_dispatch' }}
+          push: "${{ github.ref_type == 'tag' }} || github.event_name == 'workflow_dispatch' }}"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
     branches: [main]
 
-workflow_dispatch:
-  inputs:
-    fedora_version:
-      description: 'Fedora version to build with (e.g. 39, 40, latest)'
-      required: true
-      default: 'latest'
-      type: string
+  workflow_dispatch:
+    inputs:
+      fedora_version:
+        description: 'Fedora version to build with (e.g. 39, 40, latest)'
+        required: true
+        default: 'latest'
+        type: string
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -62,7 +62,7 @@ jobs:
           context: .
           file: rootc-build/Containerfile
           platforms: linux/amd64
-          push: "${{ github.ref_type == 'tag' }} || github.event_name == 'workflow_dispatch' }}"
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/container-orchestrator.yml
+++ b/.github/workflows/container-orchestrator.yml
@@ -54,7 +54,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
             type=sha
-            type=raw,value=${{ inputs.fedora_version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=fedora-${{ inputs.fedora_version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/rootc-build/Containerfile
+++ b/rootc-build/Containerfile
@@ -1,10 +1,11 @@
+ARG FEDORA_VERSION=latest
+
 # Compile the orchestrator binary
 FROM rust:1.95-slim AS builder
 COPY . /workspace
 WORKDIR /workspace
 RUN cargo build --package amos-orchestrator --release
 
-ARG FEDORA_VERSION=latest
 FROM quay.io/fedora/fedora-bootc:${FEDORA_VERSION}
 
 # Copy the compiled binary from the build stage

--- a/rootc-build/Containerfile
+++ b/rootc-build/Containerfile
@@ -1,7 +1,7 @@
 ARG FEDORA_VERSION=latest
 
 # Compile the orchestrator binary
-FROM rust:1.95-slim AS builder
+FROM docker.io/rust:1.95-slim AS builder
 COPY . /workspace
 WORKDIR /workspace
 RUN cargo build --package amos-orchestrator --release

--- a/rootc-build/Containerfile
+++ b/rootc-build/Containerfile
@@ -4,9 +4,7 @@ COPY . /workspace
 WORKDIR /workspace
 RUN cargo build --package amos-orchestrator --release
 
-ARG FEDORA_VERSION=latest#
-
-# Bootable OS image (fedora-bootc)
+ARG FEDORA_VERSION=latest
 FROM quay.io/fedora/fedora-bootc:${FEDORA_VERSION}
 
 # Copy the compiled binary from the build stage

--- a/rootc-build/Containerfile
+++ b/rootc-build/Containerfile
@@ -4,8 +4,10 @@ COPY . /workspace
 WORKDIR /workspace
 RUN cargo build --package amos-orchestrator --release
 
+ARG FEDORA_VERSION=latest#
+
 # Bootable OS image (fedora-bootc)
-FROM quay.io/fedora/fedora-bootc:latest
+FROM quay.io/fedora/fedora-bootc:${FEDORA_VERSION}
 
 # Copy the compiled binary from the build stage
 COPY --from=builder /workspace/target/release/amos-orchestrator /usr/local/bin/amos-orchestrator


### PR DESCRIPTION
## Summary
make fedora version dynamic in orchestrator build


## Related Issue
#58 


## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
