### PR TITLE
ci(docs): publish rustdoc to GitHub Pages

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AMOS — API Documentation</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 42rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.6; color: #1a1a1a; }
+    h1 { margin-bottom: 0.25rem; }
+    p.sub { color: #666; margin-top: 0; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 0.75rem 0; }
+    a.crate { display: block; padding: 1rem; border: 1px solid #ddd; border-radius: 8px; text-decoration: none; color: inherit; }
+    a.crate:hover { border-color: #888; background: #fafafa; }
+    .name { font-weight: 600; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .desc { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>AMOS — Zero-Downtime Linux Updates</h1>
+  <p class="sub">Rust API documentation</p>
+  <ul>
+    <li><a class="crate" href="amos_orchestrator/index.html">
+      <span class="name">amos_orchestrator</span><br>
+      <span class="desc">Edge-device agent that orchestrates bootc/OS-tree and application container updates.</span>
+    </a></li>
+    <li><a class="crate" href="amos_api_mock_server/index.html">
+      <span class="name">amos_api_mock_server</span><br>
+      <span class="desc">Mock Cloud API serving the desired OS and application state to orchestrators.</span>
+    </a></li>
+    <li><a class="crate" href="amos_common/index.html">
+      <span class="name">amos_common</span><br>
+      <span class="desc">Shared API types, DTOs, and utilities used across the workspace.</span>
+    </a></li>
+  </ul>
+</body>
+</html>

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,10 @@
 name: Docs
 
 # Build the rustdoc API documentation and publish it to GitHub Pages.
-# Pull requests build the docs as a breakage check; only pushes to main deploy.
+#   - push to main:      build + deploy
+#   - pull_request:      build only (breakage check)
+#   - workflow_dispatch: build + deploy from the chosen branch (manual publish),
+#                        e.g. `gh workflow run docs.yml --ref <branch>`
 on:
   push:
     branches: [main]
@@ -39,8 +42,9 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    # Only deploy from main; pull requests run the build job as a check only.
-    if: github.ref == 'refs/heads/main'
+    # Deploy on pushes to main, or on a manual workflow_dispatch from any branch.
+    # Pull requests run the build job as a check only.
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+# Build the rustdoc API documentation and publish it to GitHub Pages.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Grant GITHUB_TOKEN the permissions required to deploy to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; do not cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Build documentation
+        run: cargo doc --no-deps --workspace --all-features --document-private-items
+      - name: Add index.html redirect to the orchestrator crate
+        run: echo '<meta http-equiv="refresh" content="0; url=amos_orchestrator/index.html">' > target/doc/index.html
+      - name: Remove cargo lock file from the artifact
+        run: rm -f target/doc/.lock
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,11 @@
 name: Docs
 
 # Build the rustdoc API documentation and publish it to GitHub Pages.
+# Pull requests build the docs as a breakage check; only pushes to main deploy.
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 # Grant GITHUB_TOKEN the permissions required to deploy to GitHub Pages.
@@ -26,8 +28,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build documentation
         run: cargo doc --no-deps --workspace --all-features --document-private-items
-      - name: Add index.html redirect to the orchestrator crate
-        run: echo '<meta http-equiv="refresh" content="0; url=amos_orchestrator/index.html">' > target/doc/index.html
+      - name: Add landing page
+        run: cp .github/pages/index.html target/doc/index.html
       - name: Remove cargo lock file from the artifact
         run: rm -f target/doc/.lock
       - uses: actions/configure-pages@v5
@@ -37,6 +39,8 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    # Only deploy from main; pull requests run the build job as a check only.
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
Add a workflow that runs `cargo doc` for the workspace and deploys the
generated API documentation to GitHub Pages.


## Related Issue
<!-- Link the issue this PR addresses. Use a keyword to auto-close it on merge: -->
<!-- Fixes #123  /  Closes #123  /  Refs #123 -->


## Changes
<!-- List the key changes as bullet points -->
-

## How to Test
<!-- Steps for a reviewer to verify this works -->
1.

## Checklist
- [ ] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [ ] I have added/updated tests (if applicable)
- [ ] I have updated documentation (if applicable)
