### PR TITLE
Feat 88 orchestrator logging to db

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
         },
         "amos": {
             // Update this marker when changing ./install.sh
-            "installScriptVersion": "2026-06-16 10:00"
+            "installScriptVersion": "2026-06-16 12:00"
         }
     }
 }

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -27,6 +27,10 @@ export DEBIAN_FRONTEND=noninteractive
 #
 apt-get update -y
 
+
+apt-get update -y
 # Podman CLI for interacting with the socket from podman-container
 apt-get install -y --no-install-recommends podman
+# for TPM stuff
+apt-get install -y --no-install-recommends libtss2-dev
 rm -rf /var/lib/apt/lists/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tokio-stream",
  "tower",
@@ -106,10 +108,7 @@ dependencies = [
  "clap",
  "config",
  "ed25519-dalek",
- "env_logger",
  "futures-util",
- "jsonwebtoken",
- "log",
  "mockall",
  "podman-api",
  "rand 0.10.1",
@@ -121,7 +120,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tss-esapi",
+ "tracing-journald",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -361,6 +361,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,26 +535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitfield"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
-dependencies = [
- "bitfield-macros",
-]
-
-[[package]]
-name = "bitfield-macros"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +574,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bitflags",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal 0.9.1",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +669,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -827,7 +906,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "hyperlocal",
+ "hyperlocal 0.8.0",
  "log",
  "mime",
  "paste",
@@ -1011,8 +1090,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1029,12 +1118,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1126,6 +1239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1266,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1222,26 +1352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1427,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
+]
 
 [[package]]
 name = "ff"
@@ -1420,6 +1541,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1628,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1596,7 +1733,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.2",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1720,10 +1857,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname-validator"
-version = "1.1.1"
+name = "home"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1853,6 +1993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.10.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +2019,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.10.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1903,6 +2071,21 @@ dependencies = [
  "hyper 0.14.32",
  "pin-project",
  "tokio",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2042,6 +2225,17 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2385,16 +2579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "mbox"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d142aeadbc4e8c679fc6d93fbe7efe1c021fa7d80629e615915b519e3bc6de"
-dependencies = [
- "libc",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2680,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,17 +2744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,15 +2782,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "oid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2701,6 +2899,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,41 +3009,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "picky-asn1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff038f9360b934342fb3c0a1d6e82c438a2624b51c3c6e3e6d7cf252b6f3ee3"
-dependencies = [
- "oid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-der"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d413165e4bf7f808b9a27cbaba657657a2921f0965db833f488c4d4be96dcd2e"
-dependencies = [
- "picky-asn1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-x509"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
-dependencies = [
- "base64",
- "oid",
- "picky-asn1",
- "picky-asn1-der",
  "serde",
 ]
 
@@ -3060,6 +3248,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,6 +3465,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3477,6 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3574,6 +3815,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3728,7 +3993,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
@@ -3843,16 +4108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,6 +4152,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,6 +4181,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4131,7 +4429,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "percent-encoding",
@@ -4315,6 +4613,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,12 +4728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4745,46 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "ferroid",
+ "futures",
+ "http 1.4.2",
+ "itertools",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
+dependencies = [
+ "testcontainers",
+]
 
 [[package]]
 name = "thiserror"
@@ -4636,7 +4991,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4652,6 +5007,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.4",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,11 +5054,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4735,6 +5134,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -4744,12 +5166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4757,39 +5182,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tss-esapi"
-version = "7.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f10b25a84912b894d0e6d68f4a3771c923e9c44ddaaed7920cde92ed28aa84e"
-dependencies = [
- "bitfield",
- "enumflags2",
- "getrandom 0.4.2",
- "hostname-validator",
- "log",
- "mbox",
- "num-derive",
- "num-traits",
- "oid",
- "picky-asn1",
- "picky-asn1-x509",
- "regex",
- "serde",
- "tss-esapi-sys",
- "zeroize",
-]
-
-[[package]]
-name = "tss-esapi-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f972672926a3d3d18ecc04524720e4d20b7d1664a3fb73dbf7d4274196dbd9"
-dependencies = [
- "pkg-config",
- "target-lexicon",
-]
 
 [[package]]
 name = "typeid"
@@ -4861,6 +5253,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.2",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,7 +5289,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4895,6 +5321,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -5024,7 +5456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5050,7 +5482,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5398,7 +5830,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5429,7 +5861,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5448,7 +5880,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "config",
  "ed25519-dalek",
  "futures-util",
+ "jsonwebtoken",
  "mockall",
  "podman-api",
  "rand 0.10.1",
@@ -122,6 +123,7 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
+ "tss-esapi",
 ]
 
 [[package]]
@@ -532,6 +534,26 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1352,6 +1374,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1906,12 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
@@ -2579,6 +2627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mbox"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d142aeadbc4e8c679fc6d93fbe7efe1c021fa7d80629e615915b519e3bc6de"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2802,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2851,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3009,6 +3087,41 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "picky-asn1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff038f9360b934342fb3c0a1d6e82c438a2624b51c3c6e3e6d7cf252b6f3ee3"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d413165e4bf7f808b9a27cbaba657657a2921f0965db833f488c4d4be96dcd2e"
+dependencies = [
+ "picky-asn1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
+dependencies = [
+ "base64",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
  "serde",
 ]
 
@@ -4108,6 +4221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,6 +4851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5311,39 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tss-esapi"
+version = "7.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f10b25a84912b894d0e6d68f4a3771c923e9c44ddaaed7920cde92ed28aa84e"
+dependencies = [
+ "bitfield",
+ "enumflags2",
+ "getrandom 0.4.2",
+ "hostname-validator",
+ "log",
+ "mbox",
+ "num-derive",
+ "num-traits",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-x509",
+ "regex",
+ "serde",
+ "tss-esapi-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "tss-esapi-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f972672926a3d3d18ecc04524720e4d20b7d1664a3fb73dbf7d4274196dbd9"
+dependencies = [
+ "pkg-config",
+ "target-lexicon",
+]
 
 [[package]]
 name = "typeid"

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ _image-build:
 	mkdir -p $(DIST_DIR)/qcow2 $(DIST_DIR)/image
 	mv $(DIST_DIR)/*.qcow2 $(DIST_DIR)/qcow2/disk.qcow2
 	mv $(DIST_DIR)/*.raw   $(DIST_DIR)/image/disk.raw
-	sudo chown -R $$USER:$$USER $(DIST_DIR)
+	sudo chown -R $$USER $(DIST_DIR)
 
 pull-image: ARCH ?= $(HOST_ARCH)
 pull-image: _image-pull ## Download prebuilt disk image from GHCR for host arch into ./dist

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -13,10 +13,6 @@ chrono = { workspace = true }
 clap = { workspace = true }
 config = { workspace = true }
 ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
-env_logger = { workspace = true }
-futures-util = "0.3.32"
-jsonwebtoken = { workspace = true }
-log = { workspace = true }
 podman-api = { version = "0.11", default-features = false }
 reqwest = { version = "0.13.3", features = ["json"] }
 rsa = { version = "0.9.10", features = ["pem"] }
@@ -24,7 +20,9 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = "0.1.44"
-tss-esapi = "7.7.0"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-journald = "0.3"
+futures-util = "0.3.32"
 
 [dev-dependencies]
 serial_test = "3.4.0"

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -19,10 +19,12 @@ rsa = { version = "0.9.10", features = ["pem"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tss-esapi = "7.7.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-journald = "0.3"
 futures-util = "0.3.32"
+jsonwebtoken = { workspace = true }
 
 [dev-dependencies]
 serial_test = "3.4.0"

--- a/orchestrator/src/application.rs
+++ b/orchestrator/src/application.rs
@@ -1,4 +1,5 @@
 use std::{sync::Arc, time::Duration};
+use tracing::{debug, error, info, warn};
 
 use crate::podman::{PodmanContainer, PodmanContainerState, PodmanImage, PodmanImageInfo};
 
@@ -172,24 +173,21 @@ impl EventReceiver for LogEventReceiver {
     fn send(&self, event: LifecycleEvent) {
         match event {
             LifecycleEvent::StateChange(None, state) => {
-                log::info!("Application {} has state {:?}", self.app_name, state)
+                info!("Application {} has state {:?}", self.app_name, state)
             }
-            LifecycleEvent::StateChange(Some(old_state), new_state) => log::info!(
+            LifecycleEvent::StateChange(Some(old_state), new_state) => info!(
                 "Application {} changed state: {:?} -> {:?}",
-                self.app_name,
-                old_state,
-                new_state
+                self.app_name, old_state, new_state
             ),
             LifecycleEvent::StoppedUnexpectedly => {
-                log::warn!("Application {} stopped unexpectedly", self.app_name)
+                warn!("Application {} stopped unexpectedly", self.app_name)
             }
-            LifecycleEvent::FailureThresholdReached(failures) => log::warn!(
+            LifecycleEvent::FailureThresholdReached(failures) => warn!(
                 "Application {} seems to have trouble starting (encountered {} failures)",
-                self.app_name,
-                failures
+                self.app_name, failures
             ),
-            LifecycleEvent::AttemptingStart => log::debug!("Trying to start {}", self.app_name),
-            LifecycleEvent::FatalError(e) => log::error!("{:?}", e),
+            LifecycleEvent::AttemptingStart => debug!("Trying to start {}", self.app_name),
+            LifecycleEvent::FatalError(e) => error!("{:?}", e),
         }
     }
 }

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -10,9 +10,10 @@ use amos_common::entities::{ApplicationAssignment, ApplicationConfig, OsAssignme
 use anyhow::{Context, Result};
 use chrono::Utc;
 use futures_util::future::join_all;
-use reqwest::Client;
-use std::sync::Arc;
-use tracing::{debug, info, warn};
+use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::{Client, ClientBuilder};
+use tokio::sync::{Mutex, RwLock};
+use tracing::{debug, info};
 
 pub struct TokenState {
     pub token: String,

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -10,10 +10,9 @@ use amos_common::entities::{ApplicationAssignment, ApplicationConfig, OsAssignme
 use anyhow::{Context, Result};
 use chrono::Utc;
 use futures_util::future::join_all;
-use log::{debug, info};
-use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{Client, ClientBuilder};
-use tokio::sync::{Mutex, RwLock};
+use reqwest::Client;
+use std::sync::Arc;
+use tracing::{info, warn};
 
 pub struct TokenState {
     pub token: String,

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -12,6 +12,7 @@ use chrono::Utc;
 use futures_util::future::join_all;
 use reqwest::Client;
 use std::sync::Arc;
+use tracing::{debug, info, warn};
 use tracing::{info, warn};
 
 pub struct TokenState {
@@ -111,7 +112,13 @@ impl DownloadManager {
         self.ensure_auth_not_expired().await?;
 
         let assignment = self.get_target_os_assignment().await?;
-        self.get_os_version_by_id(assignment.os_version_id).await
+        let version = self.get_os_version_by_id(assignment.os_version_id).await?;
+        debug!(
+            os_version_id = version.id,
+            commit_hash = %version.commit_hash,
+            "Resolved target OS version",
+        );
+        Ok(version)
     }
 
     async fn get_target_os_assignment(&self) -> Result<OsAssignment::Model> {
@@ -224,6 +231,7 @@ impl DownloadManager {
             configs.push(result?);
         }
 
+        debug!(count = configs.len(), "Resolved target application configs");
         Ok(configs)
     }
 

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -13,7 +13,6 @@ use futures_util::future::join_all;
 use reqwest::Client;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
-use tracing::{info, warn};
 
 pub struct TokenState {
     pub token: String,

--- a/orchestrator/src/inventory.rs
+++ b/orchestrator/src/inventory.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use log::{info, warn};
+use tracing::{info, warn};
 use serde::Serialize;
 
 use crate::util::bootc_wrapper::{Bootc, BootcStatus};

--- a/orchestrator/src/inventory.rs
+++ b/orchestrator/src/inventory.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use tracing::{info, warn};
 use serde::Serialize;
+use tracing::{info, warn};
 
 use crate::util::bootc_wrapper::{Bootc, BootcStatus};
 use crate::util::executer::Executer;

--- a/orchestrator/src/logging.rs
+++ b/orchestrator/src/logging.rs
@@ -76,9 +76,12 @@ where
     }
 }
 
-/// Initialize the global tracing subscriber with three sinks: stdout, journald
-/// (when available), and an in-memory stub for the future DB shipper. Must be
-/// called from inside a Tokio runtime so the stub consumer task can be spawned.
+/// Initialize the global tracing subscriber with a console/journal sink plus an
+/// in-memory stub for the future DB shipper. Must be called from inside a Tokio
+/// runtime so the stub consumer task can be spawned.
+///
+/// log to journald *or* stdout, never both, to avoid duplicate journal
+/// entries: under systemd, stdout is already captured into the journal
 pub fn init(verbosity: u8, device_uuid: &str) {
     let level = match verbosity {
         0 => "warn",
@@ -93,8 +96,20 @@ pub fn init(verbosity: u8, device_uuid: &str) {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
 
-    let stdout_layer = fmt::layer().with_target(true);
-    let journald_layer = tracing_journald::layer().ok();
+    // Try journald only when systemd has wired our stdout to the journal;
+    // otherwise we want plain console output for interactive/dev runs.
+    let journald_layer = if std::env::var_os("JOURNAL_STREAM").is_some() {
+        tracing_journald::layer().ok()
+    } else {
+        None
+    };
+    // Use stdout when not under systemd, or as a fallback if connecting to the
+    // journald socket failed
+    let stdout_layer = if journald_layer.is_none() {
+        Some(fmt::layer().with_target(true))
+    } else {
+        None
+    };
 
     let (tx, rx) = mpsc::unbounded_channel::<LogEntry>();
     let db_stub_layer = DbStubLayer { sender: tx };

--- a/orchestrator/src/logging.rs
+++ b/orchestrator/src/logging.rs
@@ -1,18 +1,94 @@
-use tracing_subscriber::layer::SubscriberExt;
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::{EnvFilter, Layer, fmt};
 
-/// Initialize the global tracing subscriber with two sinks: stdout and journald
-/// (the journald sink is silently skipped when not running under systemd).
-pub fn init(verbosity: u8) {
+const DB_STUB_TARGET: &str = "amos_orchestrator::db_stub";
+
+/// Shaped to match the `POST /v1/logs/devices` request body in
+/// `Documentation/log_api.md`. a future HTTP shipper may serializes this directly.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LogEntry {
+    pub time: DateTime<Utc>,
+    pub level: &'static str,
+    pub message: String,
+    pub source: Option<String>,
+}
+
+struct MessageVisitor {
+    message: Option<String>,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        }
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        }
+    }
+}
+
+fn level_str(level: &Level) -> &'static str {
+    match *level {
+        Level::ERROR => "error",
+        Level::WARN => "warn",
+        Level::INFO => "info",
+        Level::DEBUG => "debug",
+        Level::TRACE => "trace",
+    }
+}
+
+struct DbStubLayer {
+    sender: UnboundedSender<LogEntry>,
+}
+
+impl<S> Layer<S> for DbStubLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        // The stub itself uses tracing for its periodic summary; skip those
+        // events to avoid feeding our own output back into the channel.
+        if metadata.target() == DB_STUB_TARGET {
+            return;
+        }
+        let mut visitor = MessageVisitor { message: None };
+        event.record(&mut visitor);
+        let Some(message) = visitor.message else {
+            return;
+        };
+        let entry = LogEntry {
+            time: Utc::now(),
+            level: level_str(metadata.level()),
+            message,
+            source: metadata.module_path().map(str::to_owned),
+        };
+        let _ = self.sender.send(entry);
+    }
+}
+
+/// Initialize the global tracing subscriber with three sinks: stdout, journald
+/// (when available), and an in-memory stub for the future DB shipper. Must be
+/// called from inside a Tokio runtime so the stub consumer task can be spawned.
+pub fn init(verbosity: u8, device_uuid: &str) {
     let level = match verbosity {
         0 => "warn",
         1 => "info",
         2 => "debug",
         _ => "trace",
     };
-    // Restrict to our own crates by default so dependency logs don't pollute
-    // stdout or the journal. `RUST_LOG` overrides the default when set.
+    // Restrict to our own crates by default; everything else stays at warn so
+    // dependency logs don't pollute stdout or the DB stream. `RUST_LOG`
+    // overrides the default when set.
     let default_filter = format!("amos_orchestrator={level},amos_common={level},warn");
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
@@ -20,9 +96,78 @@ pub fn init(verbosity: u8) {
     let stdout_layer = fmt::layer().with_target(true);
     let journald_layer = tracing_journald::layer().ok();
 
+    let (tx, rx) = mpsc::unbounded_channel::<LogEntry>();
+    let db_stub_layer = DbStubLayer { sender: tx };
+
     tracing_subscriber::registry()
         .with(env_filter)
         .with(stdout_layer)
         .with(journald_layer)
+        .with(db_stub_layer)
         .init();
+
+    spawn_db_stub_consumer(rx, device_uuid.to_owned());
+}
+
+fn spawn_db_stub_consumer(mut rx: UnboundedReceiver<LogEntry>, device_uuid: String) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.tick().await;
+        let mut buffered: u64 = 0;
+        loop {
+            tokio::select! {
+                maybe_entry = rx.recv() => {
+                    match maybe_entry {
+                        Some(_entry) => buffered += 1,
+                        None => return,
+                    }
+                }
+                _ = interval.tick() => {
+                    if buffered > 0 {
+                        tracing::info!(
+                            target: DB_STUB_TARGET,
+                            device_uuid = %device_uuid,
+                            buffered,
+                            "db log stub: would have shipped entries to POST /v1/logs/devices",
+                        );
+                        buffered = 0;
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_stub_layer_captures_event_fields() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<LogEntry>();
+        let layer = DbStubLayer { sender: tx };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("hello from test");
+        });
+        let entry = rx.try_recv().expect("expected one entry");
+        assert_eq!(entry.level, "info");
+        assert_eq!(entry.message, "hello from test");
+        let source = entry.source.expect("module_path should be set");
+        assert!(
+            source.starts_with("amos_orchestrator"),
+            "unexpected source: {source}",
+        );
+    }
+
+    #[test]
+    fn db_stub_layer_skips_its_own_target() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<LogEntry>();
+        let layer = DbStubLayer { sender: tx };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: DB_STUB_TARGET, "heartbeat");
+        });
+        assert!(rx.try_recv().is_err());
+    }
 }

--- a/orchestrator/src/logging.rs
+++ b/orchestrator/src/logging.rs
@@ -1,0 +1,28 @@
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, fmt};
+
+/// Initialize the global tracing subscriber with two sinks: stdout and journald
+/// (the journald sink is silently skipped when not running under systemd).
+pub fn init(verbosity: u8) {
+    let level = match verbosity {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    // Restrict to our own crates by default so dependency logs don't pollute
+    // stdout or the journal. `RUST_LOG` overrides the default when set.
+    let default_filter = format!("amos_orchestrator={level},amos_common={level},warn");
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
+
+    let stdout_layer = fmt::layer().with_target(true);
+    let journald_layer = tracing_journald::layer().ok();
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stdout_layer)
+        .with(journald_layer)
+        .init();
+}

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -2,8 +2,11 @@ use std::iter::Peekable;
 use std::sync::Arc;
 use std::time::Duration;
 
+use amos_common::entities::ApplicationConfig;
 use amos_common::entities::ApplicationConfig::Model;
 use tokio::sync::Mutex;
+use tokio::time::interval;
+use tracing::{debug, error, info, warn};
 
 use crate::application::Application;
 use crate::download_manager::DownloadManager;

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use amos_common::entities::ApplicationConfig;
-use tokio::time::interval;
-use tracing::{debug, error, info, warn};
+use tokio::sync::Mutex;
+use tracing::warn;
 
 use crate::application::Application;
 use crate::download_manager::DownloadManager;
@@ -27,7 +27,7 @@ pub async fn run_apps_main_loop(
         update_interval.tick().await;
 
         if let Err(e) = try_update(&agent_state.apps_state, &podman, &download_manager).await {
-            log::warn!("Failed to update applications: {:?}", e);
+            warn!("Failed to update applications: {:?}", e);
         }
     }
 }
@@ -45,7 +45,7 @@ async fn try_update(
 
     impl<'a, P: PodmanImage> TargetApp<'a, P> {
         async fn from_config(
-            cfg: &'a Model,
+            cfg: &'a ApplicationConfig::Model,
             podman: &'a impl Podman<PImage<'a> = P>,
         ) -> anyhow::Result<Self> {
             Ok(Self {

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use amos_common::entities::ApplicationConfig;
-use amos_common::entities::ApplicationConfig::Model;
-use tokio::sync::Mutex;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
 

--- a/orchestrator/src/loop_os.rs
+++ b/orchestrator/src/loop_os.rs
@@ -2,10 +2,10 @@ use crate::download_manager::DownloadManager;
 use crate::state::{AgentState, OsState};
 use crate::update_check::{CheckForUpdate, UpdateDecision};
 use crate::util::bootc_wrapper::Bootc;
-use tracing::{error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
+use tracing::{error, info, warn};
 
 pub async fn run_os_tree_main_loop(
     agent_state: AgentState,
@@ -44,8 +44,9 @@ pub async fn run_os_tree_main_loop(
             }
         };
 
+        let update_pending = bootc_status.staged.is_some();
         let current_os_state = OsState {
-            update_pending: bootc_status.staged.is_some(),
+            update_pending,
             booted_image: booted_checksum.clone(),
             update_ostree_commit: bootc_status.staged.map(|s| s.checksum),
         };
@@ -72,6 +73,12 @@ pub async fn run_os_tree_main_loop(
                 for reason in &reasons {
                     info!("{}", reason);
                 }
+                if update_pending {
+                    warn!(
+                        "An update is already staged but the target has changed; \
+                         re-staging on top of the existing staged deployment",
+                    );
+                }
                 handle_bootc(&client, &booted_checksum, &target.commit_hash).await;
             }
         }
@@ -88,8 +95,10 @@ async fn handle_bootc(client: &Bootc, booted_checksum: &str, target_commit: &str
         Ok(()) => {
             info!("bootc switch staged successfully. Applying and rebooting...");
 
-            if let Err(e) = client.apply().await {
-                error!("Critical: switch succeeded but apply failed: {:?}", e);
+            // Last log line before the reboot
+            match client.apply().await {
+                Ok(()) => info!(target_commit, "bootc apply succeeded; reboot imminent",),
+                Err(e) => error!("Critical: switch succeeded but apply failed: {:?}", e),
             }
         }
         Err(e) => {

--- a/orchestrator/src/loop_os.rs
+++ b/orchestrator/src/loop_os.rs
@@ -2,7 +2,7 @@ use crate::download_manager::DownloadManager;
 use crate::state::{AgentState, OsState};
 use crate::update_check::{CheckForUpdate, UpdateDecision};
 use crate::util::bootc_wrapper::Bootc;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -53,7 +53,17 @@ struct Cli {
 async fn main() {
     let cli = Cli::parse();
 
-    logging::init(cli.debug);
+    // Load config first so logging can be tagged with the device UUID. The
+    // logging subscriber isn't up yet, so failures go straight to stderr.
+    // FIXME: think about how to handle/log failed config reads.
+    //   they should be logged and sent to remote db but also include the device UUID
+    //   depens on how UUID will be provided in the future.
+    let config = Arc::new(get_config(cli.config.clone()).unwrap_or_else(|err| {
+        eprintln!("Failed to load config: {err}");
+        std::process::exit(1);
+    }));
+
+    logging::init(cli.debug, &config.device_uuid);
 
     let signer = match util::tpm::tpm_init() {
         Ok(signer) => signer,
@@ -78,12 +88,6 @@ async fn main() {
     }
 
     info!("Started app...");
-
-    let config = Arc::new(get_config(cli.config).unwrap_or_else(|err| {
-        error!("Failed to load config: {}", err);
-        std::process::exit(1);
-    }));
-
     debug!("Loaded config: {:?}", config);
 
     info!("Collecting initial inventory");

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,7 +1,7 @@
 mod config_loader;
 use clap::Parser;
 use config_loader::get_config;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::application::Application;
 use crate::loop_os::run_os_tree_main_loop;

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,7 +1,7 @@
 mod config_loader;
 use clap::Parser;
 use config_loader::get_config;
-use log::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::application::Application;
 use crate::loop_os::run_os_tree_main_loop;
@@ -18,6 +18,7 @@ mod application;
 mod download_manager;
 mod healthcheck;
 mod inventory;
+mod logging;
 mod loop_apps;
 mod loop_os;
 mod podman;
@@ -52,13 +53,7 @@ struct Cli {
 async fn main() {
     let cli = Cli::parse();
 
-    // Adjust log level according to verbosity specified via CLI
-    let mut log_level = log::LevelFilter::Warn;
-    for _ in 0..cli.debug {
-        log_level = log_level.increment_severity();
-    }
-
-    env_logger::builder().filter_level(log_level).init();
+    logging::init(cli.debug);
 
     let signer = match util::tpm::tpm_init() {
         Ok(signer) => signer,

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -87,7 +87,11 @@ async fn main() {
         std::process::exit(0);
     }
 
-    info!("Started app...");
+    info!(
+        version = VERSION,
+        device_uuid = %config.device_uuid,
+        "Orchestrator started",
+    );
     debug!("Loaded config: {:?}", config);
 
     info!("Collecting initial inventory");

--- a/orchestrator/src/podman/wrapper.rs
+++ b/orchestrator/src/podman/wrapper.rs
@@ -12,6 +12,7 @@ use podman_api::{
         ContainerWaitOpts, ImagePruneOpts, PullOpts,
     },
 };
+use tracing::debug;
 
 use super::{PodmanContainerState, PodmanPullBehaviour};
 
@@ -109,7 +110,7 @@ impl PodmanWrapper {
         let podman = podman_api::Podman::unix(socket_path);
 
         let status = podman.ping().await?;
-        log::debug!("Connected to Podman API {}", status.api_version);
+        debug!("Connected to Podman API {}", status.api_version);
 
         let mut instance = Self { podman };
         let containers = instance.list_containers().await?;

--- a/orchestrator/src/update_check.rs
+++ b/orchestrator/src/update_check.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use amos_common::entities::{ApplicationConfig, OsVersion};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use log::debug;
+use tracing::debug;
 
 use crate::download_manager::DownloadManager;
 use crate::inventory::{ApplicationInfo, CollectionResult};

--- a/orchestrator/src/util/bootc_wrapper.rs
+++ b/orchestrator/src/util/bootc_wrapper.rs
@@ -172,11 +172,21 @@ impl Bootc {
 
     #[allow(dead_code)]
     pub async fn rollback(&self) -> Result<()> {
+        info!("Rolling back to previous bootc deployment");
         let args = vec!["rollback".to_string(), "--apply".to_string()];
         let res = self.run_bootc_root(args).await?;
 
         // Use helper to treat 137 as success
-        self.handle_exit_code(res.exit_code)
+        match self.handle_exit_code(res.exit_code) {
+            Ok(()) => {
+                info!("bootc rollback succeeded; reboot imminent");
+                Ok(())
+            }
+            Err(e) => {
+                error!(exit_code = ?res.exit_code, "bootc rollback failed");
+                Err(e)
+            }
+        }
     }
 
     #[allow(dead_code)]

--- a/orchestrator/src/util/tpm.rs
+++ b/orchestrator/src/util/tpm.rs
@@ -1,9 +1,9 @@
 use std::fs;
 use std::str::FromStr as _;
 
-use log::{debug, warn};
 use rsa::pkcs8::EncodePublicKey as _;
 use rsa::{BigUint, RsaPublicKey};
+use tracing::{debug, warn};
 use tss_esapi::constants::SessionType;
 use tss_esapi::handles::{KeyHandle, PersistentTpmHandle};
 use tss_esapi::interface_types::algorithm::HashingAlgorithm;


### PR DESCRIPTION
## Summary
- switches logging in orchestrator to `tracing` crate
- logs to systemd/jounald
- preparation for sending logs to remote DB


## Related Issue
<!-- Link the issue this PR addresses. Use a keyword to auto-close it on merge: -->
<!-- Fixes #123  /  Closes #123  /  Refs #123 -->
Closes #88 

## Changes
<!-- List the key changes as bullet points -->
- see summary above

## How to Test
<!-- Steps for a reviewer to verify this works -->
test cases or running in vm

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
