### PR TITLE
90 store device logs in database

### DIFF
--- a/api-mock-server/src/api_v1/routes/logs.rs
+++ b/api-mock-server/src/api_v1/routes/logs.rs
@@ -10,7 +10,7 @@ use crate::api_v1::routes::{
 };
 use crate::api_v1::ts_db;
 use amos_common::entities::{
-    ApplicationLog, DeviceLog, LogEvent, LogLevel, LogQuery, LogStreamQuery,
+    ApplicationLog, DeviceLog, LogEvent, LogKind, LogLevel, LogQuery, LogStreamQuery,
 };
 use axum::{
     Json, Router,
@@ -188,7 +188,18 @@ pub(super) fn matches(
     device_id: Option<i32>,
     application_id: Option<i32>,
     min_level: Option<LogLevel>,
+    kind: Option<LogKind>,
 ) -> bool {
+    if let Some(kind) = kind {
+        let event_kind = match event {
+            LogEvent::Device(_) => LogKind::Device,
+            LogEvent::Application(_) => LogKind::Application,
+        };
+        if event_kind != kind {
+            return false;
+        }
+    }
+
     if let Some(device_id) = device_id
         && event.device_id() != device_id
     {
@@ -217,7 +228,7 @@ async fn stream_logs(
     let rx = log_stream::sender().subscribe();
     let stream = BroadcastStream::new(rx)
         .filter_map(|item: Result<LogEvent, BroadcastStreamRecvError>| item.ok())
-        .filter(move |event| matches(event, params.device_id, params.application_id, params.level))
+        .filter(move |event| matches(event, params.device_id, params.application_id, params.level, params.kind))
         .map(|event| Ok(Event::default().json_data(&event).unwrap()));
 
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
@@ -256,34 +267,50 @@ mod tests {
     #[test]
     fn matches_with_no_filters_returns_true() {
         let event = device_log_event(1, LogLevel::Info);
-        assert!(matches(&event, None, None, None));
+        assert!(matches(&event, None, None, None, None));
     }
 
     #[test]
     fn matches_filters_by_device_id() {
         let event = device_log_event(1, LogLevel::Info);
-        assert!(matches(&event, Some(1), None, None));
-        assert!(!matches(&event, Some(2), None, None));
+        assert!(matches(&event, Some(1), None, None, None));
+        assert!(!matches(&event, Some(2), None, None, None));
     }
 
     #[test]
     fn matches_filters_by_application_id() {
         let event = application_log_event(1, 5, LogLevel::Info);
-        assert!(matches(&event, None, Some(5), None));
-        assert!(!matches(&event, None, Some(6), None));
+        assert!(matches(&event, None, Some(5), None, None));
+        assert!(!matches(&event, None, Some(6), None, None));
     }
 
     #[test]
     fn matches_application_id_filter_excludes_device_events() {
         let event = device_log_event(1, LogLevel::Info);
-        assert!(!matches(&event, None, Some(5), None));
+        assert!(!matches(&event, None, Some(5), None, None));
     }
 
     #[test]
     fn matches_filters_by_minimum_level() {
         let event = device_log_event(1, LogLevel::Warn);
-        assert!(matches(&event, None, None, Some(LogLevel::Warn)));
-        assert!(matches(&event, None, None, Some(LogLevel::Info)));
-        assert!(!matches(&event, None, None, Some(LogLevel::Error)));
+        assert!(matches(&event, None, None, Some(LogLevel::Warn), None));
+        assert!(matches(&event, None, None, Some(LogLevel::Info), None));
+        assert!(!matches(&event, None, None, Some(LogLevel::Error), None));
+    }
+
+    #[test]
+    fn matches_filters_by_kind_device() {
+        let device_event = device_log_event(1, LogLevel::Info);
+        let app_event = application_log_event(1, 5, LogLevel::Info);
+        assert!(matches(&device_event, None, None, None, Some(LogKind::Device)));
+        assert!(!matches(&app_event, None, None, None, Some(LogKind::Device)));
+    }
+
+    #[test]
+    fn matches_filters_by_kind_application() {
+        let device_event = device_log_event(1, LogLevel::Info);
+        let app_event = application_log_event(1, 5, LogLevel::Info);
+        assert!(matches(&app_event, None, None, None, Some(LogKind::Application)));
+        assert!(!matches(&device_event, None, None, None, Some(LogKind::Application)));
     }
 }

--- a/api-mock-server/src/api_v1/routes/logs.rs
+++ b/api-mock-server/src/api_v1/routes/logs.rs
@@ -228,7 +228,15 @@ async fn stream_logs(
     let rx = log_stream::sender().subscribe();
     let stream = BroadcastStream::new(rx)
         .filter_map(|item: Result<LogEvent, BroadcastStreamRecvError>| item.ok())
-        .filter(move |event| matches(event, params.device_id, params.application_id, params.level, params.kind))
+        .filter(move |event| {
+            matches(
+                event,
+                params.device_id,
+                params.application_id,
+                params.level,
+                params.kind,
+            )
+        })
         .map(|event| Ok(Event::default().json_data(&event).unwrap()));
 
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
@@ -302,15 +310,39 @@ mod tests {
     fn matches_filters_by_kind_device() {
         let device_event = device_log_event(1, LogLevel::Info);
         let app_event = application_log_event(1, 5, LogLevel::Info);
-        assert!(matches(&device_event, None, None, None, Some(LogKind::Device)));
-        assert!(!matches(&app_event, None, None, None, Some(LogKind::Device)));
+        assert!(matches(
+            &device_event,
+            None,
+            None,
+            None,
+            Some(LogKind::Device)
+        ));
+        assert!(!matches(
+            &app_event,
+            None,
+            None,
+            None,
+            Some(LogKind::Device)
+        ));
     }
 
     #[test]
     fn matches_filters_by_kind_application() {
         let device_event = device_log_event(1, LogLevel::Info);
         let app_event = application_log_event(1, 5, LogLevel::Info);
-        assert!(matches(&app_event, None, None, None, Some(LogKind::Application)));
-        assert!(!matches(&device_event, None, None, None, Some(LogKind::Application)));
+        assert!(matches(
+            &app_event,
+            None,
+            None,
+            None,
+            Some(LogKind::Application)
+        ));
+        assert!(!matches(
+            &device_event,
+            None,
+            None,
+            None,
+            Some(LogKind::Application)
+        ));
     }
 }

--- a/common/src/entities.rs
+++ b/common/src/entities.rs
@@ -15,7 +15,7 @@ pub use crate::entities::group as Group;
 
 pub mod log;
 pub use crate::entities::log::{
-    ApplicationLog, DeviceLog, LogEvent, LogLevel, LogQuery, LogStreamQuery,
+    ApplicationLog, DeviceLog, LogEvent, LogKind, LogLevel, LogQuery, LogStreamQuery,
 };
 
 pub mod os_assignment;

--- a/common/src/entities/log/mod.rs
+++ b/common/src/entities/log/mod.rs
@@ -10,6 +10,13 @@ pub use self::log_level::LogLevel;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogKind {
+    Device,
+    Application,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum LogEvent {
@@ -40,13 +47,15 @@ impl LogEvent {
     }
 }
 
-/// Query params for `GET /logs/stream`: `?device_id=&application_id=&level=`
+/// Query params for `GET /logs/stream`: `?device_id=&application_id=&level=&kind=`
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct LogStreamQuery {
     pub device_id: Option<i32>,
     pub application_id: Option<i32>,
     /// Minimum severity: events with a level lower than this are excluded.
     pub level: Option<LogLevel>,
+    /// Restrict to a single log kind: `device` or `application`.
+    pub kind: Option<LogKind>,
 }
 
 /// Query params for the historic log endpoints:

--- a/orchestrator/src/config_loader.rs
+++ b/orchestrator/src/config_loader.rs
@@ -14,6 +14,15 @@ fn default_inventory_path() -> String {
 fn default_podman_path() -> String {
     "/run/podman/podman.sock".to_owned()
 }
+fn default_log_flush_interval_secs() -> u64 {
+    60
+}
+fn default_log_max_batch() -> usize {
+    256
+}
+fn default_log_max_buffer() -> usize {
+    10_000
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
@@ -32,6 +41,15 @@ pub struct Settings {
     pub https_proxy: Option<String>,
 
     pub device_uuid: String,
+
+    #[serde(default = "default_log_flush_interval_secs")]
+    pub log_flush_interval_secs: u64,
+
+    #[serde(default = "default_log_max_batch")]
+    pub log_max_batch: usize,
+
+    #[serde(default = "default_log_max_buffer")]
+    pub log_max_buffer: usize,
 }
 
 /// Loads and validates the orchestrator configuration.
@@ -88,6 +106,9 @@ mod tests {
             podman_path: default_podman_path(),
             https_proxy: None,
             device_uuid: "00000000-0000-0000-0000-000000000000".into(),
+            log_flush_interval_secs: default_log_flush_interval_secs(),
+            log_max_batch: default_log_max_batch(),
+            log_max_buffer: default_log_max_buffer(),
         }
     }
 

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -320,6 +320,7 @@ impl DownloadManager {
         Ok(())
     }
 
+    #[allow(dead_code)] // TODO: remove when implementing podman application logs
     /// Pushes application log entries for a given application to the API.
     /// POSTs to `/logs/applications?device_uuid=<uuid>`.
     pub async fn push_application_logs(

--- a/orchestrator/src/download_manager.rs
+++ b/orchestrator/src/download_manager.rs
@@ -6,7 +6,9 @@ use crate::util::tpm::TpmSigner;
 use amos_common::Page;
 use amos_common::entities::reported_application_assignment::CreateModel as ReportedApplicationAssignmentCreate;
 use amos_common::entities::reported_os_assignment::CreateModel as ReportedOsAssignmentCreate;
-use amos_common::entities::{ApplicationAssignment, ApplicationConfig, OsAssignment, OsVersion};
+use amos_common::entities::{
+    ApplicationAssignment, ApplicationConfig, ApplicationLog, DeviceLog, OsAssignment, OsVersion,
+};
 use anyhow::{Context, Result};
 use chrono::Utc;
 use futures_util::future::join_all;
@@ -286,6 +288,73 @@ impl DownloadManager {
         resp.json::<ApplicationConfig::Model>()
             .await
             .with_context(|| format!("Failed to parse application config {} response", id))
+    }
+
+    /// Pushes device log entries to the API.
+    /// POSTs to `/logs/devices?device_uuid=<uuid>`.
+    pub async fn push_device_logs(&self, entries: Vec<DeviceLog::CreateEntry>) -> Result<()> {
+        self.ensure_auth_not_expired().await?;
+
+        let url = format!(
+            "{}/logs/devices?device_uuid={}",
+            self.config.cloud_url, self.config.device_uuid
+        );
+
+        let body = DeviceLog::CreateModel { entries };
+
+        let resp = self
+            .http_client
+            .read()
+            .await
+            .post(&url)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            .with_context(|| format!("Failed to reach server at {}", &self.config.cloud_url))?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("Server responded with status {} for {}", resp.status(), url);
+        }
+
+        Ok(())
+    }
+
+    /// Pushes application log entries for a given application to the API.
+    /// POSTs to `/logs/applications?device_uuid=<uuid>`.
+    pub async fn push_application_logs(
+        &self,
+        application_id: i32,
+        entries: Vec<ApplicationLog::CreateEntry>,
+    ) -> Result<()> {
+        self.ensure_auth_not_expired().await?;
+
+        let url = format!(
+            "{}/logs/applications?device_uuid={}",
+            self.config.cloud_url, self.config.device_uuid
+        );
+
+        let body = ApplicationLog::CreateModel {
+            application_id,
+            entries,
+        };
+
+        let resp = self
+            .http_client
+            .read()
+            .await
+            .post(&url)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            .with_context(|| format!("Failed to reach server at {}", &self.config.cloud_url))?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("Server responded with status {} for {}", resp.status(), url);
+        }
+
+        Ok(())
     }
 
     /// Reports the current running application config for this device to the API.

--- a/orchestrator/src/logging.rs
+++ b/orchestrator/src/logging.rs
@@ -1,4 +1,7 @@
-use chrono::{DateTime, Utc};
+use std::sync::Arc;
+
+use amos_common::entities::{DeviceLog, LogLevel};
+use chrono::Utc;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
@@ -7,17 +10,9 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer, fmt};
 
-const DB_STUB_TARGET: &str = "amos_orchestrator::db_stub";
+use crate::download_manager::DownloadManager;
 
-/// Shaped to match the `POST /v1/logs/devices` request body in
-/// `Documentation/log_api.md`. a future HTTP shipper may serializes this directly.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct LogEntry {
-    pub time: DateTime<Utc>,
-    pub level: &'static str,
-    pub message: String,
-    pub source: Option<String>,
-}
+const LOG_INTERNAL_TARGET: &str = "amos_orchestrator::log_internal";
 
 struct MessageVisitor {
     message: Option<String>,
@@ -36,29 +31,29 @@ impl Visit for MessageVisitor {
     }
 }
 
-fn level_str(level: &Level) -> &'static str {
+fn tracing_level_to_log_level(level: &Level) -> LogLevel {
     match *level {
-        Level::ERROR => "error",
-        Level::WARN => "warn",
-        Level::INFO => "info",
-        Level::DEBUG => "debug",
-        Level::TRACE => "trace",
+        Level::ERROR => LogLevel::Error,
+        Level::WARN => LogLevel::Warn,
+        Level::INFO => LogLevel::Info,
+        Level::DEBUG => LogLevel::Debug,
+        Level::TRACE => LogLevel::Trace,
     }
 }
 
-struct DbStubLayer {
-    sender: UnboundedSender<LogEntry>,
+struct DeviceLogLayer {
+    sender: UnboundedSender<DeviceLog::CreateEntry>,
 }
 
-impl<S> Layer<S> for DbStubLayer
+impl<S> Layer<S> for DeviceLogLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let metadata = event.metadata();
-        // The stub itself uses tracing for its periodic summary; skip those
-        // events to avoid feeding our own output back into the channel.
-        if metadata.target() == DB_STUB_TARGET {
+        // Skip shipper diagnostics to prevent a feedback loop where API
+        // failures generate logs that re-enter the channel and amplify.
+        if metadata.target() == LOG_INTERNAL_TARGET {
             return;
         }
         let mut visitor = MessageVisitor { message: None };
@@ -66,9 +61,9 @@ where
         let Some(message) = visitor.message else {
             return;
         };
-        let entry = LogEntry {
-            time: Utc::now(),
-            level: level_str(metadata.level()),
+        let entry = DeviceLog::CreateEntry {
+            time: Some(Utc::now()),
+            level: tracing_level_to_log_level(metadata.level()),
             message,
             source: metadata.module_path().map(str::to_owned),
         };
@@ -76,13 +71,14 @@ where
     }
 }
 
-/// Initialize the global tracing subscriber with a console/journal sink plus an
-/// in-memory stub for the future DB shipper. Must be called from inside a Tokio
-/// runtime so the stub consumer task can be spawned.
+/// Initialize the global tracing subscriber and capture layer.
+///
+/// Returns the receiver end of the log channel. Pass it to
+/// `spawn_log_shipper` once the `DownloadManager` is ready.
 ///
 /// log to journald *or* stdout, never both, to avoid duplicate journal
 /// entries: under systemd, stdout is already captured into the journal
-pub fn init(verbosity: u8, device_uuid: &str) {
+pub fn init(verbosity: u8) -> UnboundedReceiver<DeviceLog::CreateEntry> {
     let level = match verbosity {
         0 => "warn",
         1 => "info",
@@ -111,41 +107,55 @@ pub fn init(verbosity: u8, device_uuid: &str) {
         None
     };
 
-    let (tx, rx) = mpsc::unbounded_channel::<LogEntry>();
-    let db_stub_layer = DbStubLayer { sender: tx };
+    let (tx, rx) = mpsc::unbounded_channel::<DeviceLog::CreateEntry>();
+    let device_log_layer = DeviceLogLayer { sender: tx };
 
     tracing_subscriber::registry()
         .with(env_filter)
         .with(stdout_layer)
         .with(journald_layer)
-        .with(db_stub_layer)
+        .with(device_log_layer)
         .init();
 
-    spawn_db_stub_consumer(rx, device_uuid.to_owned());
+    rx
 }
 
-fn spawn_db_stub_consumer(mut rx: UnboundedReceiver<LogEntry>, device_uuid: String) {
+/// Spawn the background task that ships buffered device log entries to the API.
+///
+/// Call this after the `DownloadManager` is constructed. Events emitted
+/// between `init` and this call are buffered in the channel and shipped on
+/// the first flush.
+pub fn spawn_log_shipper(
+    mut rx: UnboundedReceiver<DeviceLog::CreateEntry>,
+    download_manager: Arc<DownloadManager>,
+) {
+    let config = Arc::clone(&download_manager.config);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+            config.log_flush_interval_secs,
+        ));
         interval.tick().await;
-        let mut buffered: u64 = 0;
+        let mut buffer: Vec<DeviceLog::CreateEntry> = Vec::new();
+
         loop {
             tokio::select! {
                 maybe_entry = rx.recv() => {
                     match maybe_entry {
-                        Some(_entry) => buffered += 1,
-                        None => return,
+                        Some(entry) => {
+                            buffer.push(entry);
+                            if buffer.len() >= config.log_max_batch {
+                                flush(&mut buffer, &download_manager, config.log_max_buffer).await;
+                            }
+                        }
+                        None => {
+                            flush(&mut buffer, &download_manager, config.log_max_buffer).await;
+                            return;
+                        }
                     }
                 }
                 _ = interval.tick() => {
-                    if buffered > 0 {
-                        tracing::info!(
-                            target: DB_STUB_TARGET,
-                            device_uuid = %device_uuid,
-                            buffered,
-                            "db log stub: would have shipped entries to POST /v1/logs/devices",
-                        );
-                        buffered = 0;
+                    if !buffer.is_empty() {
+                        flush(&mut buffer, &download_manager, config.log_max_buffer).await;
                     }
                 }
             }
@@ -153,20 +163,54 @@ fn spawn_db_stub_consumer(mut rx: UnboundedReceiver<LogEntry>, device_uuid: Stri
     });
 }
 
+async fn flush(
+    buffer: &mut Vec<DeviceLog::CreateEntry>,
+    download_manager: &DownloadManager,
+    max_buffer: usize,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    match download_manager.push_device_logs(buffer.clone()).await {
+        Ok(()) => {
+            buffer.clear();
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: LOG_INTERNAL_TARGET,
+                error = %err,
+                buffered = buffer.len(),
+                "Failed to ship device logs; will retry on next flush",
+            );
+            // Drop oldest entries when the buffer exceeds the cap to bound
+            // memory usage during a sustained cloud outage.
+            if buffer.len() > max_buffer {
+                let drop_count = buffer.len() - max_buffer;
+                buffer.drain(..drop_count);
+                tracing::warn!(
+                    target: LOG_INTERNAL_TARGET,
+                    dropped = drop_count,
+                    "Dropped oldest device log entries due to buffer cap",
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn db_stub_layer_captures_event_fields() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<LogEntry>();
-        let layer = DbStubLayer { sender: tx };
+    fn device_log_layer_captures_event_fields() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<DeviceLog::CreateEntry>();
+        let layer = DeviceLogLayer { sender: tx };
         let subscriber = tracing_subscriber::registry().with(layer);
         tracing::subscriber::with_default(subscriber, || {
             tracing::info!("hello from test");
         });
         let entry = rx.try_recv().expect("expected one entry");
-        assert_eq!(entry.level, "info");
+        assert_eq!(entry.level, LogLevel::Info);
         assert_eq!(entry.message, "hello from test");
         let source = entry.source.expect("module_path should be set");
         assert!(
@@ -176,12 +220,12 @@ mod tests {
     }
 
     #[test]
-    fn db_stub_layer_skips_its_own_target() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<LogEntry>();
-        let layer = DbStubLayer { sender: tx };
+    fn device_log_layer_skips_its_own_target() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<DeviceLog::CreateEntry>();
+        let layer = DeviceLogLayer { sender: tx };
         let subscriber = tracing_subscriber::registry().with(layer);
         tracing::subscriber::with_default(subscriber, || {
-            tracing::info!(target: DB_STUB_TARGET, "heartbeat");
+            tracing::info!(target: LOG_INTERNAL_TARGET, "heartbeat");
         });
         assert!(rx.try_recv().is_err());
     }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -53,6 +53,8 @@ struct Cli {
 async fn main() {
     let cli = Cli::parse();
 
+    info!("Orchestrator starting ...");
+
     // Load config first so logging can be tagged with the device UUID. The
     // logging subscriber isn't up yet, so failures go straight to stderr.
     // FIXME: think about how to handle/log failed config reads.
@@ -141,7 +143,9 @@ async fn main() {
         },
     );
 
+    info!("Log shipper starting");
     logging::spawn_log_shipper(log_rx, Arc::clone(&download_manager));
+    info!("Log shipper started");
 
     let update_checker: Arc<dyn CheckForUpdate> =
         Arc::new(UpdateChecker::new(Arc::clone(&download_manager)));
@@ -169,7 +173,10 @@ async fn main() {
         }
     });
 
+    info!("Background workers spawned, orchestrator is running");
+
     tokio::signal::ctrl_c().await.unwrap();
+    info!("Received shutdown signal, stopping");
 }
 
 #[cfg(test)]

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -63,7 +63,7 @@ async fn main() {
         std::process::exit(1);
     }));
 
-    logging::init(cli.debug, &config.device_uuid);
+    let log_rx = logging::init(cli.debug);
 
     let signer = match util::tpm::tpm_init() {
         Ok(signer) => signer,
@@ -140,6 +140,8 @@ async fn main() {
             }
         },
     );
+
+    logging::spawn_log_shipper(log_rx, Arc::clone(&download_manager));
 
     let update_checker: Arc<dyn CheckForUpdate> =
         Arc::new(UpdateChecker::new(Arc::clone(&download_manager)));


### PR DESCRIPTION
## Summary
Sends all device logs to the api-server


## Related Issue
<!-- Link the issue this PR addresses. Use a keyword to auto-close it on merge: -->
<!-- Fixes #123  /  Closes #123  /  Refs #123 -->
Closes #90


## Changes
<!-- List the key changes as bullet points -->
- add log pushing to the tracing/logging of the orchestrator
- add functioon to the download manager to publish application and device logs

## How to Test
<!-- Steps for a reviewer to verify this works -->
1. Run test_logs.sh in scripts
2. Check if timescaledb contains expected logs

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
