### PR TITLE
Feat/105 store podman logs

### DIFF
--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 amos-common = { workspace = true }
 
 anyhow = { workspace = true }
+async-stream = "0.3.6"
 async-trait = "0.1"
 base64 = { workspace = true }
 chrono = { workspace = true }
@@ -19,6 +20,7 @@ rsa = { version = "0.9.10", features = ["pem"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tss-esapi = "7.7.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/orchestrator/src/application.rs
+++ b/orchestrator/src/application.rs
@@ -30,7 +30,11 @@ impl Application {
             app_name: container.name().to_owned(),
         };
 
-        registry.add(application_id, container.log_handle().logs(true, None));
+        registry.add(
+            application_id,
+            container.name().to_owned(),
+            container.log_handle().logs(true, None),
+        );
 
         Application {
             image_reference: container.reference().to_owned(),

--- a/orchestrator/src/application.rs
+++ b/orchestrator/src/application.rs
@@ -1,8 +1,10 @@
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
-use crate::podman::{PodmanContainer, PodmanContainerState, PodmanImage, PodmanImageInfo};
-
+use crate::podman::log_registry::AppLogRegistry;
+use crate::podman::{
+    PodmanContainer, PodmanContainerState, PodmanImage, PodmanImageInfo, PodmanLogHandle,
+};
 /// Struct to manage lifecycle of an application.
 /// Create it from an existing container by calling PodmanContainer::into,
 /// then it will try to keep it alive.
@@ -12,19 +14,28 @@ use crate::podman::{PodmanContainer, PodmanContainerState, PodmanImage, PodmanIm
 pub struct Application {
     image_reference: String,
     image_digest: String,
+    application_id: i32,
     lifecycle_loop: tokio::task::JoinHandle<()>,
     delete_notifier: Arc<tokio::sync::Notify>,
 }
 
 impl Application {
-    pub fn wrap(container: impl PodmanContainer) -> Self {
+    pub fn wrap(
+        container: impl PodmanContainer,
+        application_id: i32,
+        registry: &AppLogRegistry,
+    ) -> Self {
         let delete_notifier = Arc::new(tokio::sync::Notify::const_new());
         let event_recv = LogEventReceiver {
             app_name: container.name().to_owned(),
         };
+
+        registry.add(application_id, container.log_handle().logs(true, None));
+
         Application {
             image_reference: container.reference().to_owned(),
             image_digest: container.digest().to_owned(),
+            application_id,
             lifecycle_loop: tokio::spawn(run_lifecycle_loop(
                 container,
                 event_recv,
@@ -38,12 +49,15 @@ impl Application {
         image: &impl PodmanImage,
         name: &str,
         environment: impl IntoIterator<Item = (&str, &str)> + Send,
+        application_id: i32,
+        registry: &AppLogRegistry,
     ) -> anyhow::Result<Self> {
         let container = image.create_container(name, environment).await?;
-        Ok(Self::wrap(container))
+        Ok(Self::wrap(container, application_id, registry))
     }
 
-    pub async fn remove(mut self) -> anyhow::Result<()> {
+    pub async fn remove(mut self, registry: &AppLogRegistry) -> anyhow::Result<()> {
+        registry.remove(self.application_id);
         self.delete_notifier.notify_one();
         (&mut self.lifecycle_loop).await?;
         Ok(())
@@ -197,6 +211,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use futures_util::StreamExt;
 
     use super::{LifecycleEvent::*, *};
     use crate::podman::PodmanContainerState::{Ambiguous, Running, Stopped};
@@ -217,6 +232,23 @@ mod tests {
     impl EventReceiver for ChannelEventReceiver {
         fn send(&self, event: LifecycleEvent) {
             self.tx.send(event).unwrap()
+        }
+    }
+
+    struct NoopLogHandle;
+
+    impl crate::podman::PodmanLogHandle for NoopLogHandle {
+        fn logs(
+            self,
+            _follow: bool,
+            _since: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> futures_util::stream::BoxStream<'static, anyhow::Result<crate::podman::LogChunk>>
+        {
+            futures_util::stream::empty().boxed()
+        }
+
+        fn name(&self) -> &str {
+            "testname"
         }
     }
 
@@ -248,6 +280,11 @@ mod tests {
                     panic!("Waiting forever in test");
                 }
                 Ok(())
+            }
+
+            type LogHandle = NoopLogHandle;
+            fn log_handle(&self) -> Self::LogHandle {
+                NoopLogHandle
             }
             fn name(&self) -> &str {
                 "testname"
@@ -308,6 +345,10 @@ mod tests {
                     tokio::time::sleep(Duration::MAX).await;
                 }
                 Ok(())
+            }
+            type LogHandle = NoopLogHandle;
+            fn log_handle(&self) -> Self::LogHandle {
+                NoopLogHandle
             }
             fn name(&self) -> &str {
                 "testname"
@@ -380,6 +421,10 @@ mod tests {
                 }
                 Ok(())
             }
+            type LogHandle = NoopLogHandle;
+            fn log_handle(&self) -> Self::LogHandle {
+                NoopLogHandle
+            }
             fn name(&self) -> &str {
                 "testname"
             }
@@ -451,6 +496,10 @@ mod tests {
                     _ => {}
                 }
                 Ok(())
+            }
+            type LogHandle = NoopLogHandle;
+            fn log_handle(&self) -> Self::LogHandle {
+                NoopLogHandle
             }
             fn name(&self) -> &str {
                 "testname"

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -90,7 +90,13 @@ async fn try_update(
                     .image(&cfg.image, PullIfMissing)
                     .await?
                     .ok_or(anyhow::anyhow!("Could not pull image"))?,
-                name: &cfg.image,
+                name: cfg.image
+                    .split('/')
+                    .last()
+                    .unwrap_or(&cfg.image)
+                    .split(':')
+                    .next()
+                    .unwrap_or(&cfg.image),
                 environment: vec![],
                 application_id: cfg.id,
             })

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -90,9 +90,10 @@ async fn try_update(
                     .image(&cfg.image, PullIfMissing)
                     .await?
                     .ok_or(anyhow::anyhow!("Could not pull image"))?,
-                name: cfg.image
+                name: cfg
+                    .image
                     .split('/')
-                    .last()
+                    .next_back()
                     .unwrap_or(&cfg.image)
                     .split(':')
                     .next()

--- a/orchestrator/src/loop_apps.rs
+++ b/orchestrator/src/loop_apps.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use crate::application::Application;
 use crate::download_manager::DownloadManager;
 use crate::podman::PodmanPullBehaviour::PullIfMissing;
+use crate::podman::log_registry::AppLogRegistry;
 use crate::podman::{Podman, PodmanImage, PodmanImageInfo};
 use crate::state::AgentState;
 
@@ -16,6 +17,7 @@ pub async fn run_apps_main_loop(
     agent_state: AgentState,
     podman: impl Podman,
     download_manager: Arc<DownloadManager>,
+    registry: AppLogRegistry,
 ) {
     let mut update_interval = tokio::time::interval(Duration::from_secs(
         agent_state.config.poll_interval_secs as u64,
@@ -26,21 +28,56 @@ pub async fn run_apps_main_loop(
     loop {
         update_interval.tick().await;
 
-        if let Err(e) = try_update(&agent_state.apps_state, &podman, &download_manager).await {
+        if let Err(e) = try_update(
+            &agent_state.apps_state,
+            &podman,
+            &download_manager,
+            &registry,
+        )
+        .await
+        {
             warn!("Failed to update applications: {:?}", e);
         }
     }
+}
+
+pub fn resolve_application_ids<C: PodmanImageInfo>(
+    containers: Vec<C>,
+    target_app_configs: &[ApplicationConfig::Model],
+) -> (Vec<(C, i32)>, Vec<C>) {
+    let mut matched = Vec::new();
+    let mut unmatched = Vec::new();
+
+    for container in containers {
+        let app_ref = container
+            .reference()
+            .split(':')
+            .next()
+            .unwrap_or(container.reference());
+        let found = target_app_configs
+            .iter()
+            .find(|cfg| cfg.image.split(':').next().unwrap_or(&cfg.image) == app_ref);
+
+        match found {
+            Some(cfg) => matched.push((container, cfg.id)),
+            None => unmatched.push(container),
+        }
+    }
+
+    (matched, unmatched)
 }
 
 async fn try_update(
     apps_state: &Mutex<Vec<Application>>,
     podman: &impl Podman,
     download_manager: &DownloadManager,
+    registry: &AppLogRegistry,
 ) -> anyhow::Result<()> {
     struct TargetApp<'a, P: PodmanImage> {
         image: P,
         name: &'a str,
         environment: Vec<(&'a str, &'a str)>,
+        application_id: i32,
     }
 
     impl<'a, P: PodmanImage> TargetApp<'a, P> {
@@ -55,6 +92,7 @@ async fn try_update(
                     .ok_or(anyhow::anyhow!("Could not pull image"))?,
                 name: &cfg.image,
                 environment: vec![],
+                application_id: cfg.id,
             })
         }
     }
@@ -90,26 +128,33 @@ async fn try_update(
         for action in ReconcileIterator::new(&apps, target) {
             match action {
                 ReconcileAction::Create { image } => {
-                    let app =
-                        Application::launch_from_image(&image.image, image.name, image.environment)
-                            .await?;
+                    let app = Application::launch_from_image(
+                        &image.image,
+                        image.name,
+                        image.environment,
+                        image.application_id,
+                        registry,
+                    )
+                    .await?;
                     apps.push(app);
                 }
                 ReconcileAction::Update {
                     application_index,
                     target_image,
                 } => {
-                    apps.swap_remove(application_index).remove().await?;
+                    apps.swap_remove(application_index).remove(registry).await?;
                     let app = Application::launch_from_image(
                         &target_image.image,
                         target_image.name,
                         target_image.environment,
+                        target_image.application_id,
+                        registry,
                     )
                     .await?;
                     apps.push(app);
                 }
                 ReconcileAction::Remove { application_index } => {
-                    apps.swap_remove(application_index).remove().await?;
+                    apps.swap_remove(application_index).remove(registry).await?;
                 }
             }
         }
@@ -299,5 +344,21 @@ mod tests {
             })
         ));
         assert!(iter.next().is_none())
+    }
+
+    #[test]
+    fn resolve_application_ids_matches_by_reference() {
+        let configs = vec![ApplicationConfig::Model {
+            id: 1,
+            application_id: 1,
+            config: Some("testconfig".into()),
+            image: "docker.io/alpine:1.0".into(),
+            comment: Some("testcomment".into()),
+        }];
+        let containers = vec![MockApplication::new("docker.io/alpine:1.0", "digest1")];
+        let (matched, unmatched) = resolve_application_ids(containers, &configs);
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].1, 1);
+        assert!(unmatched.is_empty());
     }
 }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -5,12 +5,13 @@ use tracing::{debug, error, info, warn};
 
 use crate::application::Application;
 use crate::loop_os::run_os_tree_main_loop;
+use crate::podman::PodmanContainer;
+use crate::podman::log_registry::spawn_app_log_registry;
 use crate::podman::wrapper::PodmanWrapper;
 use crate::state::OsState;
 use crate::update_check::{CheckForUpdate, UpdateChecker};
 use crate::util::bootc_wrapper::Bootc;
 use crate::util::executer::RealExecuter;
-
 use crate::{
     inventory::collect_and_save_inventory, loop_apps::run_apps_main_loop, state::AgentState,
 };
@@ -119,20 +120,6 @@ async fn main() {
         update_ostree_commit: bootc_status.staged.map(|s| s.checksum),
     };
 
-    info!("Reading inital application state");
-    let (podman, containers) = PodmanWrapper::connect(Path::new(&config.podman_path))
-        .await
-        .unwrap();
-    let apps_state = containers.into_iter().map(Application::wrap).collect();
-
-    debug!("Creating AgentState");
-    let agent_state = AgentState::new(VERSION, Arc::clone(&config), os_state, apps_state);
-
-    info!(
-        "Running amos-zero-downtime with version: {}",
-        agent_state.self_version
-    );
-
     let download_manager = Arc::new(
         match download_manager::DownloadManager::new(Arc::clone(&config), signer) {
             Ok(dm) => dm,
@@ -147,6 +134,41 @@ async fn main() {
     logging::spawn_log_shipper(log_rx, Arc::clone(&download_manager));
     info!("Log shipper started");
 
+    info!("Application log registry starting");
+    let app_log_registry = spawn_app_log_registry(Arc::clone(&download_manager));
+    info!("Application log registry started");
+
+    info!("Reading inital application state");
+    let (podman, containers) = PodmanWrapper::connect(Path::new(&config.podman_path))
+        .await
+        .unwrap();
+
+    // Idk how else to get application ids other than this
+    let target_configs = download_manager
+        .get_target_application_configs()
+        .await
+        .unwrap_or_default();
+    let (matched, unmatched) = loop_apps::resolve_application_ids(containers, &target_configs);
+
+    for c in &unmatched {
+        warn!(
+            container = c.name(),
+            "No matching application config for recovered container"
+        );
+    }
+
+    let apps_state = matched
+        .into_iter()
+        .map(|(c, id)| Application::wrap(c, id, &app_log_registry))
+        .collect();
+    debug!("Creating AgentState");
+    let agent_state = AgentState::new(VERSION, Arc::clone(&config), os_state, apps_state);
+
+    info!(
+        "Running amos-zero-downtime with version: {}",
+        agent_state.self_version
+    );
+
     let update_checker: Arc<dyn CheckForUpdate> =
         Arc::new(UpdateChecker::new(Arc::clone(&download_manager)));
 
@@ -154,6 +176,7 @@ async fn main() {
         agent_state.clone(),
         podman,
         Arc::clone(&download_manager),
+        app_log_registry.clone(),
     ));
     let _os_tree_handle = tokio::spawn(run_os_tree_main_loop(
         agent_state.clone(),

--- a/orchestrator/src/podman/log_registry.rs
+++ b/orchestrator/src/podman/log_registry.rs
@@ -27,6 +27,7 @@ enum RegistryCommand {
     /// existing stream registered under the same application_id
     Add {
         application_id: i32,
+        name: String,
         stream: AppLogStream,
     },
     /// Stop tailing logs for application_id
@@ -40,10 +41,11 @@ pub struct AppLogRegistry {
 
 impl AppLogRegistry {
     /// Start tailing stream under application_id
-    pub fn add(&self, application_id: i32, stream: AppLogStream) {
+    pub fn add(&self, application_id: i32, name: String, stream: AppLogStream) {
         // Send failures mean the registry task has shut down
         let _ = self.tx.send(RegistryCommand::Add {
             application_id,
+            name,
             stream,
         });
     }
@@ -61,6 +63,7 @@ pub fn spawn_app_log_registry(download_manager: Arc<DownloadManager>) -> AppLogR
     tokio::spawn(async move {
         let mut streams: StreamMap<i32, AppLogStream> = StreamMap::new();
         let mut buffers: HashMap<i32, Vec<ApplicationLog::CreateEntry>> = HashMap::new();
+        let mut names: HashMap<i32, String> = HashMap::new();
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(
             config.log_flush_interval_secs,
         ));
@@ -70,13 +73,15 @@ pub fn spawn_app_log_registry(download_manager: Arc<DownloadManager>) -> AppLogR
             tokio::select! {
                 cmd = rx.recv() => {
                     match cmd {
-                        Some(RegistryCommand::Add { application_id, stream }) => {
+                        Some(RegistryCommand::Add { application_id, name, stream }) => {
                             debug!(application_id, "Registering application log stream");
                             streams.insert(application_id, stream);
+                            names.insert(application_id, name);
                         }
                         Some(RegistryCommand::Remove { application_id }) => {
                             debug!(application_id, "Unregistering application log stream");
                             streams.remove(&application_id);
+                            names.remove(&application_id);
                             if let Some(mut buffer) = buffers.remove(&application_id) {
                                 flush_application_logs(&mut buffer, application_id, &download_manager, config.log_max_buffer).await;
                             }
@@ -97,7 +102,7 @@ pub fn spawn_app_log_registry(download_manager: Arc<DownloadManager>) -> AppLogR
                                 time: chunk.time.or_else(|| Some(Utc::now())),
                                 level: stream_to_level(chunk.stream),
                                 message: chunk.message,
-                                source: None,
+                                source: names.get(&application_id).cloned(),
                             };
                             let buffer = buffers.entry(application_id).or_default();
                             buffer.push(entry);

--- a/orchestrator/src/podman/log_registry.rs
+++ b/orchestrator/src/podman/log_registry.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use amos_common::entities::{ApplicationLog, LogLevel};
+use chrono::Utc;
+use futures_util::stream::BoxStream;
+use tokio::sync::mpsc;
+use tokio_stream::{StreamExt as _, StreamMap};
+use tracing::{debug, warn};
+
+use crate::download_manager::DownloadManager;
+
+use super::{LogChunk, LogStreamKind};
+
+fn stream_to_level(stream: LogStreamKind) -> LogLevel {
+    match stream {
+        LogStreamKind::Stdout => LogLevel::Info,
+        LogStreamKind::Stderr => LogLevel::Warn,
+    }
+}
+
+type AppLogStream = BoxStream<'static, anyhow::Result<LogChunk>>;
+
+/// Commands sent to the central log registry task.
+enum RegistryCommand {
+    /// Start tailing a new application's logs. Replaces any
+    /// existing stream registered under the same application_id
+    Add {
+        application_id: i32,
+        stream: AppLogStream,
+    },
+    /// Stop tailing logs for application_id
+    Remove { application_id: i32 },
+}
+
+
+#[derive(Clone)]
+pub struct AppLogRegistry {
+    tx: mpsc::UnboundedSender<RegistryCommand>,
+}
+
+impl AppLogRegistry {
+    /// Start tailing stream under application_id
+    pub fn add(&self, application_id: i32, stream: AppLogStream) {
+        // Send failures mean the registry task has shut down
+        let _ = self.tx.send(RegistryCommand::Add {
+            application_id,
+            stream,
+        });
+    }
+
+    /// Stop tailing logs for application_id
+    pub fn remove(&self, application_id: i32) {
+        let _ = self.tx.send(RegistryCommand::Remove { application_id });
+    }
+}
+
+pub fn spawn_app_log_registry(
+    download_manager: Arc<DownloadManager>,
+) -> AppLogRegistry {
+    let config = Arc::clone(&download_manager.config);
+    let (tx, mut rx) = mpsc::unbounded_channel::<RegistryCommand>();
+
+    tokio::spawn(async move {
+        let mut streams: StreamMap<i32, AppLogStream> = StreamMap::new();
+        let mut buffers: HashMap<i32, Vec<ApplicationLog::CreateEntry>> = HashMap::new();
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(config.log_flush_interval_secs));
+        interval.tick().await;
+
+        loop {
+            tokio::select! {
+                cmd = rx.recv() => {
+                    match cmd {
+                        Some(RegistryCommand::Add { application_id, stream }) => {
+                            debug!(application_id, "Registering application log stream");
+                            streams.insert(application_id, stream);
+                        }
+                        Some(RegistryCommand::Remove { application_id }) => {
+                            debug!(application_id, "Unregistering application log stream");
+                            streams.remove(&application_id);
+                            if let Some(mut buffer) = buffers.remove(&application_id) {
+                                flush_application_logs(&mut buffer, application_id, &download_manager, config.log_max_buffer).await;
+                            }
+                        }
+                        None => {
+                            // All AppLogRegistry handles dropped
+                            for (application_id, mut buffer) in buffers.drain() {
+                                flush_application_logs(&mut buffer, application_id, &download_manager, config.log_max_buffer).await;
+                            }
+                            return;
+                        }
+                    }
+                }
+                Some((application_id, result)) = streams.next() => {
+                    match result {
+                        Ok(chunk) => {
+                            let entry = ApplicationLog::CreateEntry {
+                                time: chunk.time.or_else(|| Some(Utc::now())),
+                                level: stream_to_level(chunk.stream),
+                                message: chunk.message,
+                                source: None,
+                            };
+                            let buffer = buffers.entry(application_id).or_default();
+                            buffer.push(entry);
+                            if buffer.len() >= config.log_max_batch {
+                                let mut to_flush = std::mem::take(buffer);
+                                flush_application_logs(&mut to_flush, application_id, &download_manager, config.log_max_buffer).await;
+                                *buffers.entry(application_id).or_default() = to_flush;
+                            }
+                        }
+                        Err(e) => {
+                            warn!(application_id, error = %e, "Error reading container log stream");
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    for (application_id, buffer) in buffers.iter_mut() {
+                        if !buffer.is_empty() {
+                            flush_application_logs(buffer, *application_id, &download_manager, config.log_max_buffer).await;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    AppLogRegistry { tx }
+}
+
+async fn flush_application_logs(
+    buffer: &mut Vec<ApplicationLog::CreateEntry>,
+    application_id: i32,
+    download_manager: &DownloadManager,
+    max_buffer: usize,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    match download_manager
+        .push_application_logs(application_id, buffer.clone())
+        .await
+    {
+        Ok(()) => buffer.clear(),
+        Err(err) => {
+            warn!(
+                application_id,
+                error = %err,
+                buffered = buffer.len(),
+                "Failed to ship application logs; will retry on next flush",
+            );
+            if buffer.len() > max_buffer {
+                let drop_count = buffer.len() - max_buffer;
+                buffer.drain(..drop_count);
+                warn!(
+                    application_id,
+                    dropped = drop_count,
+                    "Dropped oldest application log entries due to buffer cap",
+                );
+            }
+        }
+    }
+}

--- a/orchestrator/src/podman/log_registry.rs
+++ b/orchestrator/src/podman/log_registry.rs
@@ -15,7 +15,7 @@ use super::{LogChunk, LogStreamKind};
 fn stream_to_level(stream: LogStreamKind) -> LogLevel {
     match stream {
         LogStreamKind::Stdout => LogLevel::Info,
-        LogStreamKind::Stderr => LogLevel::Warn,
+        LogStreamKind::Stderr => LogLevel::Error,
     }
 }
 

--- a/orchestrator/src/podman/log_registry.rs
+++ b/orchestrator/src/podman/log_registry.rs
@@ -33,7 +33,6 @@ enum RegistryCommand {
     Remove { application_id: i32 },
 }
 
-
 #[derive(Clone)]
 pub struct AppLogRegistry {
     tx: mpsc::UnboundedSender<RegistryCommand>,
@@ -55,16 +54,16 @@ impl AppLogRegistry {
     }
 }
 
-pub fn spawn_app_log_registry(
-    download_manager: Arc<DownloadManager>,
-) -> AppLogRegistry {
+pub fn spawn_app_log_registry(download_manager: Arc<DownloadManager>) -> AppLogRegistry {
     let config = Arc::clone(&download_manager.config);
     let (tx, mut rx) = mpsc::unbounded_channel::<RegistryCommand>();
 
     tokio::spawn(async move {
         let mut streams: StreamMap<i32, AppLogStream> = StreamMap::new();
         let mut buffers: HashMap<i32, Vec<ApplicationLog::CreateEntry>> = HashMap::new();
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(config.log_flush_interval_secs));
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+            config.log_flush_interval_secs,
+        ));
         interval.tick().await;
 
         loop {

--- a/orchestrator/src/podman/mock.rs
+++ b/orchestrator/src/podman/mock.rs
@@ -1,4 +1,8 @@
 // Mock Podman for testing purposes
+use chrono::{DateTime, Utc};
+use futures_util::stream::{self, BoxStream, StreamExt as _};
+
+use super::{LogChunk, LogStreamKind, PodmanLogHandle};
 
 use std::time::Duration;
 
@@ -12,6 +16,41 @@ pub struct PodmanMockContainer {
     name: String,
     reference: String,
     state: super::PodmanContainerState,
+}
+
+pub struct PodmanMockLogHandle {
+    name: String,
+}
+
+impl PodmanLogHandle for PodmanMockLogHandle {
+    fn logs(
+        self,
+        follow: bool,
+        _since: Option<DateTime<Utc>>,
+    ) -> BoxStream<'static, anyhow::Result<LogChunk>> {
+        let canned = vec![
+            Ok(LogChunk {
+                stream: LogStreamKind::Stdout,
+                time: Some(Utc::now()),
+                message: format!("[mock] {} starting up", self.name),
+            }),
+            Ok(LogChunk {
+                stream: LogStreamKind::Stdout,
+                time: Some(Utc::now()),
+                message: format!("[mock] {} ready", self.name),
+            }),
+        ];
+
+        if follow {
+            stream::iter(canned).chain(stream::pending()).boxed()
+        } else {
+            stream::iter(canned).boxed()
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[async_trait]
@@ -123,5 +162,11 @@ impl super::PodmanContainer for PodmanMockContainer {
 
     fn name(&self) -> &str {
         &self.name
+    }
+    type LogHandle = PodmanMockLogHandle;
+    fn log_handle(&self) -> Self::LogHandle {
+        PodmanMockLogHandle {
+            name: self.name.clone(),
+        }
     }
 }

--- a/orchestrator/src/podman/mod.rs
+++ b/orchestrator/src/podman/mod.rs
@@ -2,9 +2,35 @@
 #![allow(dead_code)]
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures_util::stream::BoxStream;
 
+pub mod log_registry;
 pub mod mock;
 pub mod wrapper;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogStreamKind {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Clone, Debug)]
+pub struct LogChunk {
+    pub stream: LogStreamKind,
+    pub time: Option<DateTime<Utc>>,
+    pub message: String,
+}
+
+pub trait PodmanLogHandle: Send + 'static {
+    fn logs(
+        self,
+        follow: bool,
+        since: Option<DateTime<Utc>>,
+    ) -> BoxStream<'static, anyhow::Result<LogChunk>>;
+
+    fn name(&self) -> &str;
+}
 
 #[async_trait]
 pub trait Podman: 'static {
@@ -49,6 +75,8 @@ pub trait PodmanContainer: PodmanImageInfo + Send + 'static {
     async fn state(&self) -> anyhow::Result<PodmanContainerState>;
     async fn wait_for_state_change(&self, current: PodmanContainerState) -> anyhow::Result<()>;
     fn name(&self) -> &str;
+    type LogHandle: PodmanLogHandle;
+    fn log_handle(&self) -> Self::LogHandle;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/orchestrator/src/podman/wrapper.rs
+++ b/orchestrator/src/podman/wrapper.rs
@@ -612,10 +612,7 @@ mod tests {
             .unwrap();
 
         let container = img
-            .create_container(
-                "test-logs-container",
-                vec![],
-            )
+            .create_container("test-logs-container", vec![])
             .await
             .unwrap();
 

--- a/orchestrator/src/podman/wrapper.rs
+++ b/orchestrator/src/podman/wrapper.rs
@@ -14,10 +14,44 @@ use podman_api::{
 };
 use tracing::debug;
 
+use chrono::{DateTime, Utc};
+use futures_util::stream::BoxStream;
+use podman_api::conn::TtyChunk;
+use podman_api::opts::ContainerLogsOpts;
+
+use super::{LogChunk, LogStreamKind, PodmanLogHandle};
+
 use super::{PodmanContainerState, PodmanPullBehaviour};
 
 pub struct PodmanWrapper {
     podman: podman_api::Podman,
+}
+
+/// Podman's `timestamps(true)` option prefixes every line with an
+/// RFC3339-nano timestamp followed by a space, e.g.
+/// `2026-06-20T10:15:03.123456789Z some log output`.
+///
+/// We split that prefix back out so `time` carries the real per-line
+/// timestamp from the container runtime rather than our local capture
+/// time, and `message` is just the original line content.
+fn parse_log_line(stream: LogStreamKind, bytes: &[u8]) -> LogChunk {
+    let raw = String::from_utf8_lossy(bytes);
+    let raw = raw.trim_end_matches(['\n', '\r']);
+
+    match raw.split_once(' ') {
+        Some((ts, rest)) if DateTime::parse_from_rfc3339(ts).is_ok() => LogChunk {
+            stream,
+            time: DateTime::parse_from_rfc3339(ts)
+                .ok()
+                .map(|t| t.with_timezone(&Utc)),
+            message: rest.to_owned(),
+        },
+        _ => LogChunk {
+            stream,
+            time: None,
+            message: raw.to_owned(),
+        },
+    }
 }
 
 #[async_trait]
@@ -149,6 +183,7 @@ impl PodmanWrapper {
                 let image = self.podman.images().get(c.image_id?).inspect().await.ok()?;
                 Some(PodmanWrapperContainer {
                     container: self.podman.containers().get(c.id.as_deref()?),
+                    podman: self.podman.clone(),
                     id: c.id?,
                     name: c.names?.pop()?,
                     image_ref: image.names_history?.pop()?,
@@ -203,6 +238,7 @@ impl<'a> super::PodmanImage for PodmanWrapperImage<'a> {
 
         Ok(PodmanWrapperContainer {
             container: pc.get(&output.id),
+            podman: self.podman.podman.clone(),
             id: output.id,
             name: name.to_owned(),
             image_ref: self.reference.clone(),
@@ -213,10 +249,55 @@ impl<'a> super::PodmanImage for PodmanWrapperImage<'a> {
 
 pub struct PodmanWrapperContainer {
     container: podman_api::api::Container,
+    podman: podman_api::Podman,
     id: String,
     name: String,
     image_ref: String,
     image_digest: String,
+}
+
+pub struct PodmanWrapperLogHandle {
+    podman: podman_api::Podman,
+    id: String,
+    name: String,
+}
+
+impl PodmanLogHandle for PodmanWrapperLogHandle {
+    fn logs(
+        self,
+        follow: bool,
+        since: Option<DateTime<Utc>>,
+    ) -> BoxStream<'static, anyhow::Result<LogChunk>> {
+        let mut opts = ContainerLogsOpts::builder()
+            .stdout(true)
+            .stderr(true)
+            .follow(follow)
+            .timestamps(true);
+        if let Some(since) = since {
+            opts = opts.since(since.timestamp().to_string());
+        }
+        let opts = opts.build();
+
+        // `self` (the podman client + container id) is moved into the
+        // stream body below, so everything the stream borrows from stays
+        // alive for as long as the stream itself
+        async_stream::try_stream! {
+            let container = self.podman.containers().get(&self.id);
+            let mut raw = container.logs(&opts);
+            while let Some(chunk) = raw.next().await {
+                match chunk? {
+                    TtyChunk::StdOut(b) => yield parse_log_line(LogStreamKind::Stdout, &b),
+                    TtyChunk::StdErr(b) => yield parse_log_line(LogStreamKind::Stderr, &b),
+                    _ => continue,
+                }
+            }
+        }
+        .boxed()
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl super::PodmanImageInfo for PodmanWrapperContainer {
@@ -293,6 +374,16 @@ impl super::PodmanContainer for PodmanWrapperContainer {
     fn name(&self) -> &str {
         &self.name
     }
+
+    type LogHandle = PodmanWrapperLogHandle;
+
+    fn log_handle(&self) -> Self::LogHandle {
+        PodmanWrapperLogHandle {
+            podman: self.podman.clone(),
+            id: self.id.clone(),
+            name: self.name.clone(),
+        }
+    }
 }
 
 impl From<&str> for PodmanContainerState {
@@ -308,6 +399,35 @@ impl From<&str> for PodmanContainerState {
 impl From<ContainerStatus> for PodmanContainerState {
     fn from(value: ContainerStatus) -> Self {
         value.as_ref().into()
+    }
+}
+
+#[cfg(test)]
+mod log_parsing_tests {
+    use super::*;
+
+    #[test]
+    fn parses_timestamped_line() {
+        let line = b"2026-06-20T10:15:03.123456789Z hello world";
+        let chunk = parse_log_line(LogStreamKind::Stdout, line);
+        assert_eq!(chunk.message, "hello world");
+        assert!(chunk.time.is_some());
+        assert_eq!(chunk.stream, LogStreamKind::Stdout);
+    }
+
+    #[test]
+    fn falls_back_when_prefix_is_not_a_timestamp() {
+        let line = b"not a timestamp at all";
+        let chunk = parse_log_line(LogStreamKind::Stderr, line);
+        assert_eq!(chunk.message, "not a timestamp at all");
+        assert!(chunk.time.is_none());
+    }
+
+    #[test]
+    fn strips_trailing_newline() {
+        let line = b"2026-06-20T10:15:03.000000000Z line with newline\n";
+        let chunk = parse_log_line(LogStreamKind::Stdout, line);
+        assert_eq!(chunk.message, "line with newline");
     }
 }
 
@@ -471,6 +591,49 @@ mod tests {
             PodmanContainerState::Running
         );
         container.stop().await.unwrap();
+        container.destroy().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "has to have access to the Podman socket"]
+    #[serial_test::serial]
+    async fn test_podman_container_logs() {
+        use crate::podman::{PodmanContainer, PodmanLogHandle};
+        use futures_util::StreamExt;
+
+        let (p, _) = super::PodmanWrapper::connect(Path::new(PODMAN_SOCK))
+            .await
+            .unwrap();
+
+        let img = p
+            .image("busybox", crate::podman::PodmanPullBehaviour::PullIfMissing)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let container = img
+            .create_container(
+                "test-logs-container",
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // busybox's default entrypoint with no args just prints usage and
+        // exits — give it something that actually produces output before
+        // stopping. For a quick non-following smoke test we don't even
+        // need to start() it long-term; just enough output to exist.
+
+        let log_handle = container.log_handle();
+        let mut stream = log_handle.logs(false, None); // follow=false: read what's there, then end
+
+        let mut lines = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            lines.push(chunk.unwrap());
+        }
+
+        println!("captured {} log chunks: {:#?}", lines.len(), lines);
+
         container.destroy().await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it to 2-3 sentences. -->
Adds automatic periodic batch logging of logs produced by podman containers running on the orchestrator

## Related Issue
<!-- Link the issue this PR addresses. Use a keyword to auto-close it on merge: -->
<!-- Fixes #123  /  Closes #123  /  Refs #123 -->
Closes #105

## Changes
<!-- List the key changes as bullet points -->
- Add log registry file in orchestrator/src/podman

## How to Test
<!-- Steps for a reviewer to verify this works -->
- Initialize your vm with tpm as mentioned here [tpm setup](https://github.com/amosproj/amos2026ss01-zero-downtime-linux-updates/pull/128), dont forget your primary key if you dont have one yet
```bash 
tpm2_createprimary -C o -c primary.ctx 
``` 

- Create an application, application config, application assignment in the database and link it to the vm device_id, with app_config image being `docker.io/beambam/demo-logger:latest`, which periodically logs to stdout and stderr
- Watch the logs fly in (hopefully)

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [ ] I have updated documentation (if applicable)
