### PR TITLE
Test/142 integration add tpm

### DIFF
--- a/orchestrator/src/util/bootc_wrapper.rs
+++ b/orchestrator/src/util/bootc_wrapper.rs
@@ -148,11 +148,7 @@ impl Bootc {
 
         info!(?target, "Switching system image");
 
-        let args = vec![
-            "switch".to_string(),
-            "--retain".to_string(),
-            target,
-        ];
+        let args = vec!["switch".to_string(), "--retain".to_string(), target];
 
         let res = self.run_bootc_root(args).await?;
 

--- a/orchestrator/src/util/bootc_wrapper.rs
+++ b/orchestrator/src/util/bootc_wrapper.rs
@@ -150,8 +150,6 @@ impl Bootc {
 
         let args = vec![
             "switch".to_string(),
-            "--transport".to_string(),
-            "containers-storage".to_string(),
             "--retain".to_string(),
             target,
         ];
@@ -329,8 +327,6 @@ mod tests {
                 eq(vec![
                     "bootc".to_string(),
                     "switch".to_string(),
-                    "--transport".to_string(),
-                    "containers-storage".to_string(),
                     "--retain".to_string(),
                     target_image.to_string(),
                 ]),

--- a/scripts/e2e_run_all.sh
+++ b/scripts/e2e_run_all.sh
@@ -102,8 +102,7 @@ podman run -d --name "$timescale_container" \
 
 echo "Waiting for TimescaleDB to be completely ready..."
 for i in $(seq 1 60); do
-    if podman exec "$timescale_container" pg_isready -U postgres >/dev/null 2>&1 && \
-       podman logs "$timescale_container" 2>&1 | grep -q "database system is ready to accept connections"; then
+    if podman exec "$timescale_container" pg_isready -U postgres >/dev/null 2>&1; then
         sleep 1
         echo "TimescaleDB is fully initialized and ready."
         break

--- a/scripts/e2e_run_all.sh
+++ b/scripts/e2e_run_all.sh
@@ -9,6 +9,7 @@ export VM_NAME="edge-ipc"
 SERVER_PID=""
 FAILED_COUNT=0
 PASSED_COUNT=0
+TPM_DIR="/tmp/emulated_tpm"
 
 # Color outputs
 GREEN='\033[0;32m'
@@ -27,6 +28,10 @@ cleanup() {
     echo -e "\n${NC}=== Cleaning up background processes ==="
     
     limactl shell "${VM_NAME}" -- sudo systemctl stop orchestrator.service 2>/dev/null || true
+
+    # Shut down the VM, also automatically terminates the backgrounded swtpm process
+    echo "Stopping Lima VM '${VM_NAME}'..."
+    limactl stop "${VM_NAME}" 2>/dev/null || true
 
     # 2. Terminate the mock server process group on the host machine
     if [ -n "${SERVER_PID:-}" ]; then
@@ -51,6 +56,27 @@ cleanup() {
     fi
 }
 trap cleanup EXIT
+
+echo "========================================="
+echo " Starting TPM and VM "
+echo "========================================="
+
+echo "Initializing emulated TPM in ${TPM_DIR}..."
+mkdir -p "${TPM_DIR}"
+swtpm socket --tpm2 -d --tpmstate dir="${TPM_DIR}" --ctrl type=unixio,path="${TPM_DIR}/swtpm-sock" --log level=20
+
+sleep 5
+
+echo "Booting VM '${VM_NAME}' with QEMU TPM arguments..."
+set -x
+QEMU_SYSTEM_X86_64="qemu-system-x86_64 \
+    -chardev socket,id=chrtpm,path=${TPM_DIR}/swtpm-sock \
+    -tpmdev emulator,id=tpm0,chardev=chrtpm \
+    -device tpm-tis,tpmdev=tpm0" \
+    limactl --debug start "${VM_NAME}"
+set +x
+
+sleep 2
 
 echo "========================================="
 echo " Starting api-mock-server in Background "

--- a/scripts/e2e_run_all.sh
+++ b/scripts/e2e_run_all.sh
@@ -11,6 +11,13 @@ FAILED_COUNT=0
 PASSED_COUNT=0
 TPM_DIR="/tmp/emulated_tpm"
 
+# TimescaleDB configurations
+readonly timescale_container="amos-test-timescaledb"
+readonly timescale_port=55433
+readonly timescale_url="postgres://app:4M0S@127.0.0.1:${timescale_port}/amos_timeseries"
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly devcontainer_dir="$(cd "$script_dir/../.devcontainer" && pwd)"
+
 # Color outputs
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -19,6 +26,7 @@ NC='\033[0m'
 # Test execution sequence
 TEST_SUITE=(
     "tests/e2e_seed_api.sh"
+    "tests/e2e_tpm_init.sh"
     "tests/e2e_bootc_status.sh"
     "tests/e2e_bootc_upgrade.sh"
 )
@@ -39,6 +47,10 @@ cleanup() {
         kill -- "-${SERVER_PID}" 2>/dev/null || true
         wait "${SERVER_PID}" 2>/dev/null || true
     fi
+
+    # Terminate and clean up the TimescaleDB podman container
+    echo "Stopping TimescaleDB container..."
+    podman rm -f "$timescale_container" >/dev/null 2>&1 || true
 
     echo "========================================="
     echo "             FINAL SUMMARY               "
@@ -65,18 +77,43 @@ echo "Initializing emulated TPM in ${TPM_DIR}..."
 mkdir -p "${TPM_DIR}"
 swtpm socket --tpm2 -d --tpmstate dir="${TPM_DIR}" --ctrl type=unixio,path="${TPM_DIR}/swtpm-sock" --log level=20
 
-sleep 5
+sleep 2
 
 echo "Booting VM '${VM_NAME}' with QEMU TPM arguments..."
-set -x
 QEMU_SYSTEM_X86_64="qemu-system-x86_64 \
     -chardev socket,id=chrtpm,path=${TPM_DIR}/swtpm-sock \
     -tpmdev emulator,id=tpm0,chardev=chrtpm \
     -device tpm-tis,tpmdev=tpm0" \
-    limactl --debug start "${VM_NAME}"
-set +x
+    limactl start "${VM_NAME}"
 
-sleep 2
+sleep 5
+
+echo "========================================="
+echo " Starting TimescaleDB Container "
+echo "========================================="
+
+podman rm -f "$timescale_container" >/dev/null 2>&1 || true
+echo "Starting throwaway TimescaleDB container..."
+podman run -d --name "$timescale_container" \
+    -e POSTGRES_PASSWORD=dummy \
+    -p "127.0.0.1:${timescale_port}:5432" \
+    -v "$devcontainer_dir/20_setup_timescale_db.sh:/docker-entrypoint-initdb.d/20_setup_timescale_db.sh:ro,Z" \
+    docker.io/timescale/timescaledb:latest-pg18 >/dev/null
+
+echo "Waiting for TimescaleDB to be completely ready..."
+for i in $(seq 1 60); do
+    if podman exec "$timescale_container" pg_isready -U postgres >/dev/null 2>&1 && \
+       podman logs "$timescale_container" 2>&1 | grep -q "database system is ready to accept connections"; then
+        sleep 1
+        echo "TimescaleDB is fully initialized and ready."
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "TimescaleDB did not become ready in time." >&2
+        exit 1
+    fi
+    sleep 1
+done
 
 echo "========================================="
 echo " Starting api-mock-server in Background "
@@ -86,7 +123,7 @@ echo "Clearing stale server instances..."
 pkill -f amos-api-mock-server || true
 sleep 0.5
 
-APP_DATABASE_URL="sqlite::memory:" setsid ./../target/debug/amos-api-mock-server -dd &
+APP_DATABASE_URL="sqlite::memory:" APP_TIMESCALE_DATABASE_URL="$timescale_url" setsid ./../target/debug/amos-api-mock-server -dd &
 SERVER_PID=$!
 
 echo "Waiting for mock server to bind to port ${PORT}..."
@@ -101,8 +138,14 @@ for i in $(seq 1 ${MAX_ATTEMPTS}); do
         echo "Error: Server did not become ready within timeout period." >&2
         exit 1
     fi
-    sleep 0.5
+    sleep 1
 done
+
+echo "========================================="
+echo " Ensuring VM Pre-requisites "
+echo "========================================="
+# Ensure Podman API socket is active for application state tracking
+limactl shell "${VM_NAME}" -- sudo systemctl enable --now podman.socket
 
 echo "========================================="
 echo " Running E2E Tests "

--- a/scripts/tests/e2e_bootc_status.sh
+++ b/scripts/tests/e2e_bootc_status.sh
@@ -1,35 +1,44 @@
 #!/usr/bin/env bash
-# Validates bootc status & 'Up to Date' evaluation paths
+# Validates bootc status reporting and up-to-date evaluation paths
 
 cd "$(dirname "$0")"
 source ./common_env.sh
 
 echo "=== Testing Bootc Status Evaluation ==="
 
-echo "Fetching active booted checksum from VM..."
-BOOTED_HASH=$(limactl shell "${VM_NAME}" -- sudo bootc status --json | grep -o '"checksum":"[^"]*' | grep -o '[^"]*$' | head -n 1)
+# Gather current state using JSON parsing via jq
+echo "Fetching active booted digest from VM..."
+BOOTED_DIGEST=$(limactl shell "${VM_NAME}" -- sudo bootc status --json | jq -r '.status.booted.ostree.checksum')
 
-if [ -z "${BOOTED_HASH}" ]; then
-    echo -e "${RED}Failed to extract live booted checksum from VM!${NC}"
+# Validation: ensure we didn't get an empty string or 'null' from jq
+if [ -z "${BOOTED_DIGEST}" ] || [ "${BOOTED_DIGEST}" == "null" ]; then
+    echo -e "${RED}Failed to extract live booted digest from VM via JSON!${NC}"
     exit 1
 fi
-echo "Live VM is running deployment: ${BOOTED_HASH}"
+echo "Live VM is running deployment digest: ${BOOTED_DIGEST}"
 
-# Tell the API that this matching hash is our target OS version
-api "/v1/os-versions" POST "{\"commit_hash\": \"${BOOTED_HASH}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Current Base Baseline\"}" 201
+# Setup the target assignment in the Mock API
+api "/v1/os-versions" POST "{\"commit_hash\": \"${BOOTED_DIGEST}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Current Base Baseline\"}" 201
 api "/v1/os-assignments" POST '{"os_version_id": 2, "device_id": 1}' 201
 
-# Trigger a polling loop check by restarting the agent service
-echo "Restarting Orchestrator to trigger an active status evaluation..."
+# Trigger the agent loop
+echo "Restarting Orchestrator loop to trigger check-in..."
 limactl shell "${VM_NAME}" -- sudo systemctl restart orchestrator.service
+sleep 5
 
-sleep 4
+echo "Verifying that the device reported its OS assignment upstream..."
+REPORTED_STATUS=$(curl -sS -H "Authorization: Bearer ${JWT}" "${HOST_SERVER_URL}/v1/reported-os-assignments?device_uuid=${DEVICE_UUID}")
 
-# Check the systemd log output to make sure it processed the match safely
-echo "Checking logs to confirm Orchestrator verified 'Up to Date' criteria..."
-if limactl shell "${VM_NAME}" -- sudo journalctl -u orchestrator.service -n 20 | grep -q "OS is up to date"; then
-    echo -e "${GREEN}Success: Orchestrator safely verified status and matches targets.${NC}"
+# Use jq to extract the exact os_version_id from the first record in the data array
+REPORTED_VERSION_ID=$(echo "${REPORTED_STATUS}" | jq '.data[0].os_version_id // empty')
+
+echo "API server reports active device os_version_id is: '${REPORTED_VERSION_ID}'"
+
+# Validate that a version was reported and that it maps to 1
+if [ "${REPORTED_VERSION_ID}" = "1" ]; then
+    echo -e "${GREEN}Success: Device correctly reported its OS assignment state (mapped to baseline ID 1).${NC}"
 else
-    echo -e "${RED}Failure: Orchestrator failed to log a safe 'Up to Date' status validation match.${NC}"
+    echo -e "${RED}Failure: Device did not report version 1. Received: '${REPORTED_VERSION_ID}'${NC}"
+    echo "Full response payload: ${REPORTED_STATUS}"
     exit 1
 fi

--- a/scripts/tests/e2e_bootc_upgrade.sh
+++ b/scripts/tests/e2e_bootc_upgrade.sh
@@ -28,17 +28,16 @@ echo "Awaiting Orchestrator upgrade trigger phase (allowing time for download an
 limactl shell "edge-ipc" -- sudo journalctl -u orchestrator.service -n 50 --no-pager
 sleep 15
 
-# --- VERIFY THE ACTUAL SWITCH EFFECT IN BOOTC ---
 echo "Querying live bootc deployment status for staged images..."
-BOOTC_STATUS_RAW=$(limactl shell "${VM_NAME}" -- sudo bootc status)
+BOOTC_STATUS_JSON=$(limactl shell "${VM_NAME}" -- sudo bootc status --json)
 
-if echo "${BOOTC_STATUS_RAW}" | grep -A 5 "staged" | grep -q "${TARGET_UPGRADE_REF}"; then
-    echo -e "${GREEN}Success: Verified switch deployment! Target image is staged in bootc status.${NC}"
+if echo "${BOOTC_STATUS_JSON}" | jq -e ".status.staged.image.image.image == \"${TARGET_UPGRADE_REF}\" or .status.booted.image.image.image == \"${TARGET_UPGRADE_REF}\"" > /dev/null; then
+    echo -e "${GREEN}Success: Verified switch deployment! Target image matches live bootc status.${NC}"
     echo "Current bootc status output:"
-    echo "${BOOTC_STATUS_RAW}"
+    echo "${BOOTC_STATUS_JSON}" | jq .
 else
-    echo -e "${RED}Failure: Target image '${TARGET_UPGRADE_REF}' was not found in bootc's staged status.${NC}"
+    echo -e "${RED}Failure: Target image '${TARGET_UPGRADE_REF}' was not found in staged or booted status.${NC}"
     echo "Current bootc status output:"
-    echo "${BOOTC_STATUS_RAW}"
+    echo "${BOOTC_STATUS_JSON}" | jq .
     exit 1
 fi

--- a/scripts/tests/e2e_bootc_upgrade.sh
+++ b/scripts/tests/e2e_bootc_upgrade.sh
@@ -6,34 +6,46 @@ source ./common_env.sh
 
 echo "=== Testing Bootc Switch & Apply Sequence ==="
 
-# Post an entirely new target image version to the mock API server
-TARGET_UPGRADE_HASH="092599a804d5169ae2a0a306bcb4b213b7646d28"
-echo "Registering new upgrade target: ${TARGET_UPGRADE_HASH}"
+# Define the remote target upgrade reference image
+# (it was latest at the moment of writing this)
+TARGET_UPGRADE_REF="ghcr.io/amosproj/amos2026ss01-zero-downtime-linux-updates-system:commit-4b3a71d"
 
-api "/v1/os-versions" POST "{\"commit_hash\": \"${TARGET_UPGRADE_HASH}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Target Upgrade Image Context\"}" 201
+echo "Preparing local upgrade target image inside the VM..."
+# Pre-pull the image from GHCR into root's containers-storage backend inside the VM
+limactl shell "${VM_NAME}" -- sudo podman pull "${TARGET_UPGRADE_REF}"
+
+# Seed the target upgrade assignment in the Mock API
+api "/v1/os-versions" POST "{\"commit_hash\": \"${TARGET_UPGRADE_REF}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Target GHCR Upgrade Image\"}" 201
 api "/v1/os-assignments" POST '{"os_version_id": 3, "device_id": 1}' 201
+
+echo "--- Cleaning up obsolete assignments in Cloud API ---"
+# Delete id: 1 and id: 2 so that only id: 3 remains so that it for sure has to use the new aassignment here
+curl -s -X DELETE -H "Authorization: Bearer ${JWT}" "${HOST_SERVER_URL}/v1/os-assignments/1"
+curl -s -X DELETE -H "Authorization: Bearer ${JWT}" "${HOST_SERVER_URL}/v1/os-assignments/2"
+echo "--- Obsolete assignments removed ---"
+
+echo "--- DEBUG: Current OS Assignments in Cloud API ---"
+curl -s -H "Authorization: Bearer ${JWT}" \
+    "http://127.0.0.1:${PORT}/v1/os-assignments?device_uuid=${DEVICE_UUID}" | jq '.'
+echo "---------------------------------------------------"
 
 # Force orchestrator agent iteration check
 echo "Restarting Orchestrator loop..."
 limactl shell "${VM_NAME}" -- sudo systemctl restart orchestrator.service
 
-echo "Awaiting Orchestrator upgrade trigger phase (allowing time for execution processing)..."
-sleep 6
+echo "Awaiting Orchestrator upgrade trigger phase (allowing time for download and execution)..."
+limactl shell "edge-ipc" -- sudo journalctl -u orchestrator.service -n 50 --no-pager
+sleep 15
 
-# Confirm that the application launched both its switch & staging actions
-echo "Parsing deployment execution logs..."
-LOG_OUTPUT=$(limactl shell "${VM_NAME}" -- sudo journalctl -u orchestrator.service -n 50)
+# --- VERIFY THE ACTUAL SWITCH EFFECT IN BOOTC ---
+echo "Querying live bootc deployment status for staged images..."
+BOOTC_STATUS_RAW=$(limactl shell "${VM_NAME}" -- sudo bootc status)
 
-if echo "${LOG_OUTPUT}" | grep -q "Switching OS image"; then
-    echo -e "${GREEN}Success: Found 'bootc switch' execution command logs.${NC}"
+if echo "${BOOTC_STATUS_RAW}" | grep -A 5 "staged" | grep -q "${TARGET_UPGRADE_REF}"; then
+    echo -e "${GREEN}Success: Verified switch deployment! Target image is staged in bootc status.${NC}"
 else
-    echo -e "${RED}Failure: Orchestrator never initiated an image switch loop operation.${NC}"
-    exit 1
-fi
-
-if echo "${LOG_OUTPUT}" | grep -q "bootc switch staged successfully"; then
-    echo -e "${GREEN}Success: 'bootc apply' command staging processing was logged successfully.${NC}"
-else
-    echo -e "${RED}Warning/Failure: The switch command failed or apply sequence didn't finish staging.${NC}"
+    echo -e "${RED}Failure: Target image '${TARGET_UPGRADE_REF}' was not found in bootc's staged status.${NC}"
+    echo "Current bootc status output:"
+    echo "${BOOTC_STATUS_RAW}"
     exit 1
 fi

--- a/scripts/tests/e2e_bootc_upgrade.sh
+++ b/scripts/tests/e2e_bootc_upgrade.sh
@@ -10,10 +10,6 @@ echo "=== Testing Bootc Switch & Apply Sequence ==="
 # (it was latest at the moment of writing this)
 TARGET_UPGRADE_REF="ghcr.io/amosproj/amos2026ss01-zero-downtime-linux-updates-system:commit-4b3a71d"
 
-echo "Preparing local upgrade target image inside the VM..."
-# Pre-pull the image from GHCR into root's containers-storage backend inside the VM
-limactl shell "${VM_NAME}" -- sudo podman pull "${TARGET_UPGRADE_REF}"
-
 # Seed the target upgrade assignment in the Mock API
 api "/v1/os-versions" POST "{\"commit_hash\": \"${TARGET_UPGRADE_REF}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Target GHCR Upgrade Image\"}" 201
 api "/v1/os-assignments" POST '{"os_version_id": 3, "device_id": 1}' 201
@@ -23,11 +19,6 @@ echo "--- Cleaning up obsolete assignments in Cloud API ---"
 curl -s -X DELETE -H "Authorization: Bearer ${JWT}" "${HOST_SERVER_URL}/v1/os-assignments/1"
 curl -s -X DELETE -H "Authorization: Bearer ${JWT}" "${HOST_SERVER_URL}/v1/os-assignments/2"
 echo "--- Obsolete assignments removed ---"
-
-echo "--- DEBUG: Current OS Assignments in Cloud API ---"
-curl -s -H "Authorization: Bearer ${JWT}" \
-    "http://127.0.0.1:${PORT}/v1/os-assignments?device_uuid=${DEVICE_UUID}" | jq '.'
-echo "---------------------------------------------------"
 
 # Force orchestrator agent iteration check
 echo "Restarting Orchestrator loop..."
@@ -43,6 +34,8 @@ BOOTC_STATUS_RAW=$(limactl shell "${VM_NAME}" -- sudo bootc status)
 
 if echo "${BOOTC_STATUS_RAW}" | grep -A 5 "staged" | grep -q "${TARGET_UPGRADE_REF}"; then
     echo -e "${GREEN}Success: Verified switch deployment! Target image is staged in bootc status.${NC}"
+    echo "Current bootc status output:"
+    echo "${BOOTC_STATUS_RAW}"
 else
     echo -e "${RED}Failure: Target image '${TARGET_UPGRADE_REF}' was not found in bootc's staged status.${NC}"
     echo "Current bootc status output:"

--- a/scripts/tests/e2e_seed_api.sh
+++ b/scripts/tests/e2e_seed_api.sh
@@ -4,15 +4,25 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-
 source ./tests/common_env.sh
 
 echo "=== Filling Mock Cloud Database ==="
 
-
 api "/v1/tenants" POST '{ "name": "Weber-Lager", "description": "Automated Testing Tenant" }' 201
 api "/v1/devices" POST "{\"uuid\": \"${DEVICE_UUID}\", \"hostname\": \"edge-ipc\", \"tenant_id\": 1}" 201
-api "/v1/os-versions" POST '{ "commit_hash": "092599a804d5169ae2a0a306bcb4b213b7646d28", "orchestrator_version": "0.1.0", "description": "Target Update Commit" }' 201
+
+# Dynamically fetch the current running OSTree checksum from the VM
+echo "Extracting dynamic baseline checksum from VM for database seeding..."
+DYNAMIC_CHECKSUM=$(limactl shell "${VM_NAME}" -- sudo bootc status --json | jq -r '.status.booted.ostree.checksum')
+
+if [ -z "${DYNAMIC_CHECKSUM}" ] || [ "${DYNAMIC_CHECKSUM}" == "null" ]; then
+    echo -e "${RED}Critical initialization failure: Could not extract dynamic checksum from VM.${NC}"
+    exit 1
+fi
+echo "Seeding API with Baseline Version: ${DYNAMIC_CHECKSUM}"
+
+# Inject the dynamic checksum into the JSON payload
+api "/v1/os-versions" POST "{\"commit_hash\": \"${DYNAMIC_CHECKSUM}\", \"orchestrator_version\": \"0.1.0\", \"description\": \"Dynamic Base Baseline\"}" 201
 api "/v1/os-assignments" POST '{ "os_version_id": 1, "device_id": 1 }' 201
 
 echo -e "${GREEN}Database successfully initialized with testing data.${NC}"

--- a/scripts/tests/e2e_tpm_init.sh
+++ b/scripts/tests/e2e_tpm_init.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Initializes the vTPM and registers the Edge IPC public key via the API
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source ./tests/common_env.sh
+
+echo "=== Initializing vTPM on Edge IPC ==="
+
+# Check if a persistent key already exists at 0x81000000
+if ! limactl shell "${VM_NAME}" -- sudo tpm2_getcap handles-persistent | grep -q "0x81000000"; then
+    echo "Generating new TPM primary and RSA keys..."
+    
+    # We execute this inside /tmp. Lima mounts the host working directory as read-only by default.
+    # We must move to a writable directory on the VM to save the .ctx and .pub temporary files.
+    limactl shell "${VM_NAME}" -- sudo bash -c '
+        cd /tmp
+        # Forcefully evict the handle first if it happens to be corrupted/mismatched
+        tpm2_evictcontrol -C o -c 0x81000000 2>/dev/null || true
+
+        tpm2_createprimary -C o -c primary.ctx
+        tpm2_create -C primary.ctx -G rsa -u key.pub -r key.priv
+        tpm2_load -C primary.ctx -u key.pub -r key.priv -c key.ctx
+        tpm2_evictcontrol -C o -c key.ctx 0x81000000
+        
+        rm -f primary.ctx key.pub key.priv key.ctx
+    '
+else
+    echo "TPM key already exists at handle 0x81000000."
+fi
+
+echo "Extracting public key from TPM..."
+limactl shell "${VM_NAME}" -- sudo tpm2_readpublic -c 0x81000000 -f pem -o /tmp/pubkey.pem
+
+# Read the PEM file and replace newlines with literal '\n' for the JSON payload
+PUBKEY=$(limactl shell "${VM_NAME}" -- sudo sed -z 's/\n/\\n/g' /tmp/pubkey.pem)
+
+echo "Registering public key with the API..."
+# Note: We PUT to /v1/devices/1 assuming the seed script created this device ID
+api "/v1/devices/1" PUT "{\"uuid\": \"${DEVICE_UUID}\", \"hostname\": \"${VM_NAME}\", \"tenant_id\": 1, \"public_key\": \"${PUBKEY}\"}" 200
+
+echo -e "${GREEN}vTPM successfully initialized and public key registered.${NC}"
+
+# Restart the orchestrator so it picks up the newly created TPM hardware keys and the new verbosity logging level
+echo "Restarting Orchestrator to apply TPM keys and verbosity..."
+limactl shell "${VM_NAME}" -- sudo systemctl restart orchestrator.service


### PR DESCRIPTION
## Summary

Improves integration tests with adding timescaledb and tpm adjustments as well as rewriting the conditiong for bootc status and bootc upgrade passing.

## Related Issue

Closes #142

## Changes
- Add TimescaleDB configuration
- Add TPM initialization
- Rewrite conditions for bootc status and upgrade tests.

## How to Test
1. setup lima vm
2. Change to ./scripts
3. ./e2e_run_all.sh

Currently, only 3 out of 4 tests pass. I am not sure whether it is a fault on the side of the test or the orchestrator, so I would like to know the opinion of reviewers first.

Sometimes, TimescaleDB fails to initialize, not sure about the reason (might be local). But by the second run it is normally all right.

Regarding bootc_upgrade:

Even when there is only one assignment available
```sh
[2026-06-22T18:02:43Z DEBUG amos_api_mock_server] /v1/os-assignments?device_uuid=00000000-0000-0000-0000-000000000001 -> 200 OK
{
  "page": 1,
  "page_size": 20,
  "total_items": 1,
  "total_pages": 1,
  "data": [
    {
      "id": 3,
      "os_version_id": 3,
      "device_id": 1,
      "group_id": null
    }
  ]
}
```

The device think it is up-to-date and doesn't receive new information:
```sh
apiVersion: org.containers.bootc/v1
kind: BootcHost
metadata:
  name: host
spec:
  image:
    image: localhost/amos-edge:dev
    transport: registry
  bootOrder: default
status:
  staged: null
  booted:
    image:
      image:
        image: localhost/amos-edge:dev
        transport: registry
      version: 44.20260621.0
      timestamp: 2026-06-22T10:37:32.943667299Z
      imageDigest: sha256:895e8496e4db65fbb80c06648f292b838d855c739d2cc08ca73a9e5050092131
      architecture: amd64
    cachedUpdate: null
    incompatible: false
    pinned: false
    softRebootCapable: true
    downloadOnly: false
    store: ostreeContainer
    ostree:
      stateroot: default
      checksum: 7b43f03447bed547e551f799ea8959e288477dca6a87db0ce701952355606c8e
      deploySerial: 0
    composefs: null
  rollback: null
  rollbackQueued: false
  type: bootcHost
  usrOverlay: null
```

Whereas this is supposed to be the target to be staged: `ghcr.io/amosproj/amos2026ss01-zero-downtime-linux-updates-system:commit-4b3a71d`

I suspect the in the os_loop, the polling doesn't work correctly or is cached instead of being updated properly. Might even need new adjustments after "the big refactor" anyway.

Edit: After scimming through a few PRs, it seems I tried to use features that are not yet in main? Oh well, we'll see.

## Checklist
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] My commits are signed off (`git commit -s`) for [DCO](./DCO) compliance
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
